### PR TITLE
bugfix of spherical ray

### DIFF
--- a/Ray.py
+++ b/Ray.py
@@ -92,7 +92,7 @@ class RayWorker:
                     M_angle2 = 2
                 for n in range(0,M_angle2):
                     angle2 = 2*math.pi*n/M_angle2
-                    dir = pl.multVec(Vector(math.sin(angle1)*math.cos(angle2), math.sin(angle1)*math.sin(angle2), math.cos(angle1)))
+                    dir = Vector(math.sin(angle1)*math.cos(angle2), math.sin(angle1)*math.sin(angle2), math.cos(angle1))
 
                     Ncount = Ncount+1
                     pos = pl.Base


### PR DESCRIPTION
bug fix that caused beam to deform if position of beam was not equal to the origin of the part.
By removing pl.multVec from the vector creation this was fixed.