### PR TITLE
Update icons to be consistent with FreeCAD

### DIFF
--- a/icons/Anonymous_Lightbulb_Lit.svg
+++ b/icons/Anonymous_Lightbulb_Lit.svg
@@ -1,155 +1,213 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="svg1"
-   height="64"
    width="64"
+   height="64"
+   id="svg2869"
    version="1.1"
-   sodipodi:docname="Anonymous_Lightbulb_Lit.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="2238"
-     inkscape:window-height="1251"
-     id="namedview20"
-     showgrid="false"
-     units="px"
-     inkscape:zoom="1.9802839"
-     inkscape:cx="112"
-     inkscape:cy="211.33333"
-     inkscape:window-x="0"
-     inkscape:window-y="36"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg1" />
+   viewBox="0 0 64 64"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs3">
+     id="defs2871">
     <linearGradient
-       id="linearGradient2430"
-       y2="180.23"
-       gradientUnits="userSpaceOnUse"
-       y1="277.84"
-       gradientTransform="matrix(0.81852,0,0,1.2217,-246.17,-76.297)"
-       x2="357.70999"
-       x1="543.08002">
+       id="linearGradient147">
       <stop
-         id="stop1704"
-         stop-color="#f2ff00"
-         offset="0" />
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="0"
+         id="stop147" />
       <stop
-         id="stop1705"
-         stop-color="#ffffb8"
-         offset="1" />
+         style="stop-color:#c4a000;stop-opacity:1"
+         offset="1"
+         id="stop148" />
     </linearGradient>
+    <linearGradient
+       id="linearGradient5">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop19" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop20" />
+    </linearGradient>
+    <linearGradient
+       id="swatch18">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="swatch15">
+      <stop
+         style="stop-color:#3d0000;stop-opacity:1;"
+         offset="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5-1">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient147"
+       id="radialGradient148"
+       cx="88.780167"
+       cy="110.20604"
+       fx="88.780167"
+       fy="110.20604"
+       r="89.803741"
+       gradientTransform="matrix(1.0598964,-0.12593564,0.41699233,3.5007312,-50.777645,-296.24202)"
+       gradientUnits="userSpaceOnUse" />
   </defs>
-  <g
-     id="layer1"
-     transform="matrix(0.16216438,0,0,0.16216438,16.414998,-0.410893)">
-    <g
-       id="g2420"
-       stroke="#000000"
-       stroke-width="8.75"
-       transform="translate(-15.836,-7.1981)">
-      <g
-         id="g1712"
-         stroke-linecap="round"
-         transform="translate(-252.27,-133.3)"
-         fill="none">
-        <path
-           id="path1708"
-           d="m 405.14,449.07 -72.28,25.45" />
-        <path
-           id="path1709"
-           d="M 405.14,468.75 332.86,494.2" />
-        <path
-           id="path1710"
-           d="m 405.14,488.43 -72.28,25.45" />
-        <path
-           id="path1711"
-           d="m 405.14,429.39 -72.28,25.45" />
-      </g>
-      <path
-         id="path1691"
-         stroke-linejoin="round"
-         d="M 168.43,306.31 C 167.71,195.46 192.18,179.26 201.54,167.03 215.99,148.16 227.72,102.08 202.26,61.94 169.45,9.947 96.79,-4.832 45.35,51.863 13.431,87.367 23.168,138.23 41.028,166.313 c 4.705,6.9 30.231,28.79 30.231,139.64 0,0.72 97.171,0.36 97.171,0.36 z"
-         fill="url(#linearGradient2430)"
-         fill-rule="evenodd"
-         style="fill:url(#linearGradient2430)" />
-      <path
-         id="path1080"
-         d="M 153.31,40.347 C 81.336,12.275 15.11,83.534 54.704,156.947"
-         stroke-linecap="round"
-         fill="none" />
-      <path
-         id="path1702"
-         d="M 169.87,53.303 C 184.98,63.38 192.9,79.215 196.5,91.451"
-         stroke-linecap="round"
-         fill="none" />
-      <path
-         id="path1717"
-         d="m 101.46,388.21 c 0,0 4.06,9.26 15.27,9.16 10.22,-0.09 14.25,-9.16 14.25,-9.16"
-         stroke-linecap="round"
-         fill="none" />
-    </g>
-  </g>
   <metadata
-     id="metadata17">
+     id="metadata2874">
     <rdf:RDF>
-      <cc:Work>
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <cc:license
-           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
-        <dc:publisher>
-          <cc:Agent
-             rdf:about="http://openclipart.org/">
-            <dc:title>Openclipart</dc:title>
-          </cc:Agent>
-        </dc:publisher>
-        <dc:title>Lightbulb Lit</dc:title>
-        <dc:date>2009-05-24T00:37:06</dc:date>
-        <dc:description>A lit lightbulb by Benji Park. From old OCAL site.</dc:description>
-        <dc:source>http://openclipart.org/detail/26219/lightbulb-lit-by-anonymous</dc:source>
         <dc:creator>
           <cc:Agent>
-            <dc:title>Anonymous</dc:title>
+            <dc:title>[maxwxyz]</dc:title>
           </cc:Agent>
         </dc:creator>
-        <dc:subject>
-          <rdf:Bag>
-            <rdf:li>bulb</rdf:li>
-            <rdf:li>clip art</rdf:li>
-            <rdf:li>clipart</rdf:li>
-            <rdf:li>image</rdf:li>
-            <rdf:li>media</rdf:li>
-            <rdf:li>public domain</rdf:li>
-            <rdf:li>svg</rdf:li>
-            <rdf:li>technology</rdf:li>
-          </rdf:Bag>
-        </dc:subject>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>2024</dc:date>
       </cc:Work>
-      <cc:License
-         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#Reproduction" />
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#Distribution" />
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
-      </cc:License>
     </rdf:RDF>
   </metadata>
+  <g
+     id="layer3"
+     style="display:inline">
+    <g
+       id="layer1"
+       transform="matrix(0.15326306,0,0,0.15345446,15.906603,1.4167983)"
+       style="stroke-width:13.0413;stroke-dasharray:none">
+      <g
+         id="g2420"
+         stroke="#000000"
+         stroke-width="9.25241"
+         transform="translate(-15.836,-7.1981)"
+         style="stroke-width:13.0413;stroke-dasharray:none">
+        <g
+           id="g1712"
+           stroke-linecap="round"
+           transform="matrix(0.84534442,0,0,0.84534442,-191.09103,-60.026924)"
+           fill="none"
+           style="fill:none;stroke:#0b1e23;stroke-width:23.1408;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             id="path1708"
+             d="m 410.9136,440.17031 -83.82719,29.5158"
+             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path1709"
+             d="m 410.9136,462.99432 -83.82719,29.5158"
+             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path1710"
+             d="m 410.9136,485.81832 -83.82719,29.5158"
+             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path1711"
+             d="m 410.9136,417.3463 -83.82719,29.5158"
+             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <rect
+           style="fill:#eeeeec;fill-opacity:1;stroke:#0b1d22;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+           id="rect142"
+           width="61.320667"
+           height="122.27464"
+           x="90.180725"
+           y="276.24704"
+           ry="30.857229" />
+        <g
+           id="g146"
+           stroke-linecap="round"
+           transform="matrix(0.84534442,0,0,0.84534442,-191.09103,-60.026924)"
+           fill="none"
+           style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             id="path143"
+             d="m 410.9136,440.17031 -83.82719,29.5158"
+             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path144"
+             d="m 410.9136,462.99432 -83.82719,29.5158"
+             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path145"
+             d="m 410.9136,485.81832 -83.82719,29.5158"
+             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path146"
+             d="m 410.9136,417.3463 -83.82719,29.5158"
+             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <path
+           style="fill:#d3d7cf;fill-opacity:1;stroke:#eeeeec;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+           id="rect143"
+           width="61.320667"
+           height="122.27464"
+           x="90.180725"
+           y="276.24704"
+           ry="30.857229"
+           d="m 120.8418,289.28711 c 9.72127,0 17.61914,7.89344 17.61914,17.81641 v 60.56054 c 0,9.92296 -7.89787,17.81641 -17.61914,17.81641 -9.72128,0 -17.61914,-7.89345 -17.61914,-17.81641 v -60.56054 c 0,-9.92297 7.89786,-17.81641 17.61914,-17.81641 z" />
+        <path
+           id="path1691"
+           stroke-linejoin="round"
+           d="m 168.43013,305.157 c -0.72,-110.85 23.75,-127.05 33.11,-139.28 14.45,-18.87 26.18,-64.95 0.72,-105.090002 -32.81,-51.9929997 -105.469995,-66.7719997 -156.909995,-10.077 -31.919,35.504 -22.182,86.367002 -4.322,114.450002 4.705,6.9 30.231,28.79 30.231,139.64 0,0.72 97.170995,0.36 97.170995,0.36 z"
+           fill="url(#linearGradient2430)"
+           fill-rule="evenodd"
+           style="display:inline;fill:#fce94f;stroke:#231f0b;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path147"
+           stroke-linejoin="round"
+           d="m 84.156055,292.1503 c 7.830127,0.20927 -7.423906,0.29959 71.334175,0.01 0.59811,-48.35871 6.23549,-78.57828 13.48633,-98.15625 8.09324,-21.85252 19.37938,-32.35551 22.20899,-36.05274 10.81234,-14.11964 22.55567,-54.71408 0.0605,-90.179686 l -0.008,-0.01172 -0.008,-0.01367 C 175.08419,42.159576 148.09567,27.169474 120.0957,27.511719 98.493727,27.775761 75.257452,37.159698 55.015625,59.464844 l -0.0078,0.0098 c -27.056314,30.148275 -18.384483,74.200311 -3.15039,98.390621 0.04421,0.0362 0.722275,0.60479 1.854135,1.89354 6.602985,7.45175 28.596049,39.15762 30.444498,132.39153 z"
+           fill="url(#linearGradient2430)"
+           fill-rule="evenodd"
+           style="display:inline;fill:url(#radialGradient148);stroke:#fce94f;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+    </g>
+    <path
+       style="fill:none;fill-opacity:1;stroke:#fce94f;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       d="M 30.489608,43.739282 C 30.312501,28.603051 27.132074,28.28744 26.343803,23.232841 c -0.986215,-6.32386 1.513262,2.140923 2.574643,1.262536 1.06138,-0.878387 0.07659,-7.740349 1.27064,-4.080402 1.194053,3.659948 2.2014,3.367151 3.307006,0 1.105605,-3.367151 -0.558299,7.0868 0.734795,5.147297 1.293093,-1.939503 3.285368,-6.151896 2.835933,-3.262473 C 36.541025,25.680146 32,27.66027 33.496092,43.73001"
+       id="path148" />
+  </g>
 </svg>

--- a/icons/Anonymous_Lightbulb_Off.svg
+++ b/icons/Anonymous_Lightbulb_Off.svg
@@ -1,158 +1,191 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="svg1"
-   height="64"
    width="64"
+   height="64"
+   id="svg2869"
    version="1.1"
-   sodipodi:docname="Anonymous_Lightbulb_Off.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="3840"
-     inkscape:window-height="2093"
-     id="namedview20"
-     showgrid="false"
-     inkscape:zoom="1.9740566"
-     inkscape:cx="111.33333"
-     inkscape:cy="212"
-     inkscape:window-x="0"
-     inkscape:window-y="36"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg1"
-     inkscape:document-rotation="0"
-     units="px" />
+   viewBox="0 0 64 64"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs3">
+     id="defs2871">
     <linearGradient
-       id="linearGradient2373"
-       y2="180.23"
-       gradientUnits="userSpaceOnUse"
-       y1="277.84"
-       gradientTransform="matrix(0.81852,0,0,1.2217,-246.17,-76.297)"
-       x2="357.70999"
-       x1="543.08002">
+       id="linearGradient5">
       <stop
-         id="stop2360"
-         stop-color="#dbdbdb"
-         offset="0" />
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop19" />
       <stop
-         id="stop2361"
-         stop-color="#fff"
-         offset="1" />
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop20" />
+    </linearGradient>
+    <linearGradient
+       id="swatch18">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="swatch15">
+      <stop
+         style="stop-color:#3d0000;stop-opacity:1;"
+         offset="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5-1">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1" />
     </linearGradient>
   </defs>
-  <g
-     id="layer1"
-     transform="matrix(0.15998506,0,0,0.15998506,15.844244,0.57988443)">
-    <g
-       id="g2363"
-       stroke="#000000"
-       stroke-width="8.75"
-       transform="translate(-15.835,-8.6374)">
-      <g
-         id="g1712"
-         stroke-linecap="round"
-         transform="translate(-252.27,-133.3)"
-         fill="none">
-        <path
-           id="path1708"
-           d="m 405.14,449.07 -72.28,25.45" />
-        <path
-           id="path1709"
-           d="M 405.14,468.75 332.86,494.2" />
-        <path
-           id="path1710"
-           d="m 405.14,488.43 -72.28,25.45" />
-        <path
-           id="path1711"
-           d="m 405.14,429.39 -72.28,25.45" />
-      </g>
-      <path
-         id="path1691"
-         stroke-linejoin="round"
-         d="M 168.43,306.31 C 167.71,195.46 192.18,179.26 201.54,167.03 215.99,148.16 227.72,102.08 202.26,61.94 169.45,9.947 96.79,-4.832 45.35,51.863 13.431,87.367 23.168,138.23 41.028,166.313 c 4.705,6.9 30.231,28.79 30.231,139.64 0,0.72 97.171,0.36 97.171,0.36 z"
-         fill="url(#linearGradient2373)"
-         fill-rule="evenodd"
-         style="fill:url(#linearGradient2373)" />
-      <path
-         id="path1080"
-         d="M 153.31,40.347 C 81.336,12.275 15.11,83.534 54.704,156.947"
-         stroke-linecap="round"
-         fill="none" />
-      <path
-         id="path1702"
-         d="M 169.87,53.303 C 184.98,63.38 192.9,79.215 196.5,91.451"
-         stroke-linecap="round"
-         fill="none" />
-      <path
-         id="path1717"
-         d="m 101.46,388.21 c 0,0 4.06,9.26 15.27,9.16 10.22,-0.09 14.25,-9.16 14.25,-9.16"
-         stroke-linecap="round"
-         fill="none" />
-    </g>
-  </g>
   <metadata
-     id="metadata17">
+     id="metadata2874">
     <rdf:RDF>
-      <cc:Work>
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <cc:license
-           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
-        <dc:publisher>
-          <cc:Agent
-             rdf:about="http://openclipart.org/">
-            <dc:title>Openclipart</dc:title>
-          </cc:Agent>
-        </dc:publisher>
-        <dc:title>Lightbulb Off</dc:title>
-        <dc:date>2009-05-24T00:37:48</dc:date>
-        <dc:description>An off lightbulb by Benji Park. From old OCAL site.</dc:description>
-        <dc:source>http://openclipart.org/detail/26220/lightbulb-off-by-anonymous-26220</dc:source>
         <dc:creator>
           <cc:Agent>
-            <dc:title>Anonymous</dc:title>
+            <dc:title>[maxwxyz]</dc:title>
           </cc:Agent>
         </dc:creator>
-        <dc:subject>
-          <rdf:Bag>
-            <rdf:li>black and white</rdf:li>
-            <rdf:li>bulb</rdf:li>
-            <rdf:li>clip art</rdf:li>
-            <rdf:li>clipart</rdf:li>
-            <rdf:li>image</rdf:li>
-            <rdf:li>line art</rdf:li>
-            <rdf:li>media</rdf:li>
-            <rdf:li>public domain</rdf:li>
-            <rdf:li>svg</rdf:li>
-            <rdf:li>technology</rdf:li>
-          </rdf:Bag>
-        </dc:subject>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>2024</dc:date>
       </cc:Work>
-      <cc:License
-         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#Reproduction" />
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#Distribution" />
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
-      </cc:License>
     </rdf:RDF>
   </metadata>
+  <g
+     id="layer3"
+     style="display:inline">
+    <g
+       id="layer1"
+       transform="matrix(0.15326306,0,0,0.15345446,15.906603,1.4167983)"
+       style="stroke-width:13.0413;stroke-dasharray:none">
+      <g
+         id="g2420"
+         stroke="#000000"
+         stroke-width="9.25241"
+         transform="translate(-15.836,-7.1981)"
+         style="stroke-width:13.0413;stroke-dasharray:none">
+        <g
+           id="g1712"
+           stroke-linecap="round"
+           transform="matrix(0.84534442,0,0,0.84534442,-191.09103,-60.026924)"
+           fill="none"
+           style="fill:none;stroke:#0b1e23;stroke-width:23.1408;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             id="path1708"
+             d="m 410.9136,440.17031 -83.82719,29.5158"
+             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path1709"
+             d="m 410.9136,462.99432 -83.82719,29.5158"
+             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path1710"
+             d="m 410.9136,485.81832 -83.82719,29.5158"
+             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path1711"
+             d="m 410.9136,417.3463 -83.82719,29.5158"
+             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <rect
+           style="fill:#eeeeec;fill-opacity:1;stroke:#0b1d22;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+           id="rect142"
+           width="61.320667"
+           height="122.27464"
+           x="90.180725"
+           y="276.24704"
+           ry="30.857229" />
+        <g
+           id="g146"
+           stroke-linecap="round"
+           transform="matrix(0.84534442,0,0,0.84534442,-191.09103,-60.026924)"
+           fill="none"
+           style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1">
+          <path
+             id="path143"
+             d="m 410.9136,440.17031 -83.82719,29.5158"
+             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path144"
+             d="m 410.9136,462.99432 -83.82719,29.5158"
+             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path145"
+             d="m 410.9136,485.81832 -83.82719,29.5158"
+             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             id="path146"
+             d="m 410.9136,417.3463 -83.82719,29.5158"
+             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <path
+           style="fill:#d3d7cf;fill-opacity:1;stroke:#eeeeec;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+           id="rect143"
+           width="61.320667"
+           height="122.27464"
+           x="90.180725"
+           y="276.24704"
+           ry="30.857229"
+           d="m 120.8418,289.28711 c 9.72127,0 17.61914,7.89344 17.61914,17.81641 v 60.56054 c 0,9.92296 -7.89787,17.81641 -17.61914,17.81641 -9.72128,0 -17.61914,-7.89345 -17.61914,-17.81641 v -60.56054 c 0,-9.92297 7.89786,-17.81641 17.61914,-17.81641 z" />
+        <path
+           id="path1691"
+           stroke-linejoin="round"
+           d="m 168.43013,305.157 c -0.72,-110.85 23.75,-127.05 33.11,-139.28 14.45,-18.87 26.18,-64.95 0.72,-105.090002 -32.81,-51.9929997 -105.469995,-66.7719997 -156.909995,-10.077 -31.919,35.504 -22.182,86.367002 -4.322,114.450002 4.705,6.9 30.231,28.79 30.231,139.64 0,0.72 97.170995,0.36 97.170995,0.36 z"
+           fill="url(#linearGradient2430)"
+           fill-rule="evenodd"
+           style="display:inline;fill:#d3d7cf;fill-opacity:1;stroke:#0b1d22;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path147"
+           stroke-linejoin="round"
+           d="m 84.156055,292.1503 c 7.830127,0.20927 -7.423906,0.29959 71.334175,0.01 0.59811,-48.35871 6.23549,-78.57828 13.48633,-98.15625 8.09324,-21.85252 19.37938,-32.35551 22.20899,-36.05274 10.81234,-14.11964 22.55567,-54.71408 0.0605,-90.179686 l -0.008,-0.01172 -0.008,-0.01367 C 175.08419,42.159576 148.09567,27.169474 120.0957,27.511719 98.493727,27.775761 75.257452,37.159698 55.015625,59.464844 l -0.0078,0.0098 c -27.056314,30.148275 -18.384483,74.200311 -3.15039,98.390621 0.04421,0.0362 0.722275,0.60479 1.854135,1.89354 6.602985,7.45175 28.596049,39.15762 30.444498,132.39153 z"
+           fill="url(#linearGradient2430)"
+           fill-rule="evenodd"
+           style="display:inline;fill:#babdb6;fill-opacity:0.5;stroke:#d3d7cf;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+    </g>
+    <path
+       style="fill:none;fill-opacity:1;stroke:#555753;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       d="M 30.489608,43.739282 C 30.312501,28.603051 27.132074,28.28744 26.343803,23.232841 c -0.986215,-6.32386 1.513262,2.140923 2.574643,1.262536 1.06138,-0.878387 0.07659,-7.740349 1.27064,-4.080402 1.194053,3.659948 2.2014,3.367151 3.307006,0 1.105605,-3.367151 -0.558299,7.0868 0.734795,5.147297 1.293093,-1.939503 3.285368,-6.151896 2.835933,-3.262473 C 36.541025,25.680146 32,27.66027 33.496092,43.73001"
+       id="path148" />
+  </g>
 </svg>

--- a/icons/ExportCSV.svg
+++ b/icons/ExportCSV.svg
@@ -2,97 +2,181 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="16.767509mm"
-   height="16.933331mm"
-   viewBox="0 0 16.767509 16.933331"
+   width="64"
+   height="64"
+   id="svg2869"
    version="1.1"
-   id="svg1"
-   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
-   sodipodi:docname="ExportCSV.svg"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   viewBox="0 0 64 64"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="mm"
-     inkscape:zoom="1.3843855"
-     inkscape:cx="33.227739"
-     inkscape:cy="137.24501"
-     inkscape:window-width="2560"
-     inkscape:window-height="1362"
-     inkscape:window-x="1920"
-     inkscape:window-y="40"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="layer1"
-     showgrid="false" />
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs1" />
+     id="defs2871">
+    <linearGradient
+       id="linearGradient5">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop19" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop20" />
+    </linearGradient>
+    <linearGradient
+       id="swatch18">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="swatch15">
+      <stop
+         style="stop-color:#3d0000;stop-opacity:1;"
+         offset="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5-1">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata2874">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[maxwxyz]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>2024</dc:date>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(-6.0025212,-4.7315327)">
+     id="layer3"
+     style="display:inline">
     <rect
-       style="fill:none;stroke:#000000;stroke-width:1.58335;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       style="fill:#babdb6;stroke:#0b1e23;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
        id="rect1"
-       width="12.732076"
-       height="15.349981"
-       x="6.7941961"
-       y="5.5232077" />
+       width="44.92503"
+       height="54.01569"
+       x="4.1638851"
+       y="3.772805" />
     <path
-       style="fill:none;stroke:#999999;stroke-width:1.58335;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
-       d="m 9.409543,7.7639518 h 2.53425"
-       id="path1"
-       sodipodi:nodetypes="cc" />
+       style="fill:#d3d7cf;stroke:#eeeeec;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       id="rect148"
+       width="44.92503"
+       height="54.01569"
+       x="5.2859335"
+       y="4.9921551"
+       d="M 7.2851562,6.9921875 H 48.210937 V 57.007812 H 7.2851562 Z"
+       transform="translate(-1.1220482,-1.21935)" />
     <path
-       style="fill:none;stroke:#999999;stroke-width:1.58335;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
-       d="m 14.388666,7.7650082 h 2.534251"
-       id="path1-1"
-       sodipodi:nodetypes="cc" />
+       style="fill:none;stroke:#888a85;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       d="m 13.392116,11.657853 h 8.942082"
+       id="path1" />
     <path
-       style="fill:none;stroke:#999999;stroke-width:1.58335;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
-       d="M 9.3885972,9.7410977 H 11.922848"
-       id="path1-0"
-       sodipodi:nodetypes="cc" />
+       style="fill:none;stroke:#888a85;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       d="m 30.960913,11.66157 h 8.942086"
+       id="path1-1" />
     <path
-       style="fill:none;stroke:#999999;stroke-width:1.58335;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
-       d="m 14.36772,9.7421542 h 2.534251"
-       id="path1-1-7"
-       sodipodi:nodetypes="cc" />
+       style="fill:none;stroke:#888a85;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       d="m 13.31821,18.615314 h 8.942084"
+       id="path1-0" />
     <path
-       style="fill:none;stroke:#999999;stroke-width:1.58335;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
-       d="M 9.4220187,11.72768 H 11.956269"
-       id="path1-9"
-       sodipodi:nodetypes="cc" />
+       style="fill:none;stroke:#888a85;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       d="m 30.887005,18.619032 h 8.942086"
+       id="path1-1-7" />
     <path
-       style="fill:none;stroke:#999999;stroke-width:1.58335;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
-       d="m 14.401141,11.728737 h 2.534251"
-       id="path1-1-6"
-       sodipodi:nodetypes="cc" />
+       style="fill:none;stroke:#888a85;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       d="M 13.436138,25.605981 H 22.37822"
+       id="path1-9" />
+    <path
+       style="fill:none;stroke:#888a85;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       d="m 31.004932,25.609701 h 8.942084"
+       id="path1-1-6" />
     <text
        xml:space="preserve"
-       style="font-size:3.35143px;letter-spacing:0.418931px;fill:none;stroke:#000000;stroke-width:0.395838;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
-       x="8.3240318"
-       y="16.814592"
+       style="font-size:14.0368px;letter-spacing:1.7546px;fill:#2e3436;stroke:#2e3436;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       x="10.104242"
+       y="43.37941"
        id="text1"
-       transform="scale(1.0719524,0.93287724)"><tspan
-         sodipodi:role="line"
+       transform="scale(1.0187681,0.98157766)"><tspan
          id="tspan1"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.35143px;font-family:'Century Gothic';-inkscape-font-specification:'Century Gothic';letter-spacing:0.418931px;stroke-width:0.395838;stroke-dasharray:none"
-         x="8.3240318"
-         y="16.814592">CSV</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.0368px;font-family:'Century Gothic';-inkscape-font-specification:'Century Gothic';letter-spacing:1.7546px;fill:#2e3436;stroke:#2e3436;stroke-width:0.999998;stroke-dasharray:none"
+         x="10.104242"
+         y="43.37941">CSV</tspan></text>
     <path
-       style="fill:#000000;fill-opacity:1;stroke:#b3b3b3;stroke-width:0.395838;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
-       d="m 15.638414,19.173523 v -2.037841 h 3.811513 v -1.376206 l 3.122197,2.470112 -3.162745,2.346606 v -1.402671 z"
-       id="path2"
-       sodipodi:nodetypes="cccccccc" />
+       style="fill:#729fcf;fill-opacity:1;stroke:#0c1522;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.996078"
+       d="M 30.504935,54.276829 V 45.631822 H 46.628544 V 39.793629 L 59.836179,50.272432 46.457016,60.227294 V 54.276829 Z"
+       id="path2" />
+    <path
+       style="fill:none;stroke:#eeeeec;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       d="m 13.392116,11.657853 h 8.942082"
+       id="path148" />
+    <path
+       style="fill:none;stroke:#eeeeec;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       d="m 30.960913,11.66157 h 8.942086"
+       id="path149" />
+    <path
+       style="fill:none;stroke:#eeeeec;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       d="m 13.31821,18.615314 h 8.942084"
+       id="path150" />
+    <path
+       style="fill:none;stroke:#eeeeec;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       d="m 30.887005,18.619032 h 8.942086"
+       id="path151" />
+    <path
+       style="fill:none;stroke:#eeeeec;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       d="M 13.436138,25.605981 H 22.37822"
+       id="path152" />
+    <path
+       style="fill:none;stroke:#eeeeec;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       d="m 31.004932,25.609701 h 8.942084"
+       id="path153" />
+    <path
+       style="fill:#3465a4;fill-opacity:1;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.996078"
+       d="m 49.75,45.152344 7.927734,6.289062 -8.099609,6.025391 V 53.496094 H 33.626953 V 48.851562 H 49.75 Z"
+       id="path154"
+       transform="translate(-1.1220482,-1.21935)" />
   </g>
 </svg>

--- a/icons/absorber.svg
+++ b/icons/absorber.svg
@@ -1,64 +1,118 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
-   viewBox="0 0 16.933333 16.933333"
+   id="svg2869"
    version="1.1"
-   id="svg8"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
-   sodipodi:docname="absorber.svg">
+   viewBox="0 0 64 64"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="7.9195959"
-     inkscape:cx="56.946197"
-     inkscape:cy="87.621039"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
-     inkscape:document-rotation="0"
-     showgrid="false"
-     units="px"
-     inkscape:window-width="3840"
-     inkscape:window-height="2093"
-     inkscape:window-x="0"
-     inkscape:window-y="36"
-     inkscape:window-maximized="1" />
+     id="defs2871">
+    <linearGradient
+       id="linearGradient5">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop19" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop20" />
+    </linearGradient>
+    <linearGradient
+       id="swatch18">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="swatch15">
+      <stop
+         style="stop-color:#3d0000;stop-opacity:1;"
+         offset="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5-1">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1" />
+    </linearGradient>
+  </defs>
   <metadata
-     id="metadata5">
+     id="metadata2874">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[maxwxyz]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>2024</dc:date>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Ebene 1"
-     inkscape:groupmode="layer"
-     id="layer1">
+     id="layer3"
+     style="display:inline">
     <path
-       style="fill:none;stroke:#000000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 15.53963,0.87835183 10.166636,16.485171"
+       style="fill:none;stroke:#babdb6;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 52.271589,9.5590498 36.692808,54.44095"
+       id="path47" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:12;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 52.271589,9.5590498 36.692808,54.44095"
        id="path833" />
     <path
-       style="fill:none;stroke:#ffcc00;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
-       d="M -0.0157582,8.7839223 10.849811,8.5959965"
+       style="fill:none;stroke:#221e0c;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 7.1693612,32.293792 38.673646,31.753358"
        id="path893" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 7.1693612,32.293792 38.673646,31.753358"
+       id="path45" />
+    <path
+       style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 6.978454,33.03364 38.810476,32.487584"
+       id="path46" />
   </g>
 </svg>

--- a/icons/grating.svg
+++ b/icons/grating.svg
@@ -1,73 +1,170 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
-   width="68.377388"
-   height="67.382706"
-   viewBox="0 0 68.377388 67.382706"
+   width="64"
+   height="64"
+   id="svg2869"
    version="1.1"
-   xml:space="preserve"
-   style="clip-rule:evenodd;fill-rule:evenodd"
-   id="svg17"
-   sodipodi:docname="grating.svg"
-   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   viewBox="0 0 64 64"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:serif="http://www.serif.com/"><defs
-   id="defs21" /><sodipodi:namedview
-   id="namedview19"
-   pagecolor="#ffffff"
-   bordercolor="#666666"
-   borderopacity="1.0"
-   inkscape:showpageshadow="2"
-   inkscape:pageopacity="0.0"
-   inkscape:pagecheckerboard="0"
-   inkscape:deskcolor="#d1d1d1"
-   showgrid="false"
-   inkscape:zoom="13.328125"
-   inkscape:cx="34.475967"
-   inkscape:cy="34.66354"
-   inkscape:window-width="3840"
-   inkscape:window-height="2082"
-   inkscape:window-x="0"
-   inkscape:window-y="40"
-   inkscape:window-maximized="1"
-   inkscape:current-layer="svg17" />
-    <g
-   id="Ebene-1"
-   serif:id="Ebene 1"
-   transform="translate(2.4971362,2.6157924)">
-        <path
-   id="path833"
-   d="M 58.732,3.32 38.425,62.306"
-   style="fill:none;fill-rule:nonzero;stroke:#0000ff;stroke-width:15.12px" />
-        <path
-   d="M 39.533,34.637 13.06,0"
-   style="fill:none;stroke:#00fffe;stroke-width:3.7px;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:1.5"
-   id="path3" />
-        <path
-   d="M 39.533,34.637 0,12.114 Z"
-   style="fill:none;stroke:#ff0000;stroke-width:3.7px;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:1.5"
-   id="path5" />
-        <path
-   d="M 0.094,4.866 39.533,34.637"
-   style="fill:none;stroke:#ffff00;stroke-width:3.7px;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:1.5"
-   id="path7" />
-        <path
-   d="M 39.533,34.637 C 39.579,34.251 3.958,0 3.958,0"
-   style="fill:none;stroke:#00ff00;stroke-width:3.7px;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:1.5"
-   id="path9" />
-        <path
-   d="M 39.533,34.637 21.746,0"
-   style="fill:none;stroke:#0100ff;stroke-width:3.7px;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:1.5"
-   id="path11" />
-        <path
-   d="M 39.533,34.637 28.399,0"
-   style="fill:none;stroke:#fd00ff;stroke-width:3.7px;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:1.5"
-   id="path13" />
-        <path
-   id="path835"
-   d="M 0.094,37.417 39.533,34.681 V 34.637"
-   style="fill:none;fill-rule:nonzero;stroke:#ffcc00;stroke-width:3.65px" />
-    </g>
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2871">
+    <linearGradient
+       id="linearGradient5">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop19" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop20" />
+    </linearGradient>
+    <linearGradient
+       id="swatch18">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="swatch15">
+      <stop
+         style="stop-color:#3d0000;stop-opacity:1;"
+         offset="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5-1">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata2874">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[maxwxyz]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>2024</dc:date>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer3"
+     style="display:inline">
+    <path
+       d="M 40.037807,32.033673 18.825359,4.279525"
+       style="clip-rule:evenodd;display:inline;fill:none;fill-rule:evenodd;stroke:#221e0c;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1"
+       id="path49" />
+    <path
+       d="M 40.037807,32.033673 5.3642055,12.279201 Z"
+       style="clip-rule:evenodd;display:inline;fill:none;fill-rule:evenodd;stroke:#221e0c;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1"
+       id="path50" />
+    <path
+       d="M 5.3642055,5.8598907 40.037807,32.033673"
+       style="clip-rule:evenodd;display:inline;fill:none;fill-rule:evenodd;stroke:#221e0c;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1"
+       id="path51" />
+    <path
+       style="fill:none;stroke:#0b1523;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 53.635795,9.8385748 38.057013,54.720475"
+       id="path47" />
+    <path
+       d="m 40.037807,32.033673 c 0.046,-0.386 -29.673601,-27.754148 -29.673601,-27.754148"
+       style="clip-rule:evenodd;display:inline;fill:none;fill-rule:evenodd;stroke:#221e0c;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1"
+       id="path52" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:12;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 53.635795,9.8385748 38.057013,54.720475"
+       id="path833" />
+    <path
+       d="M 40.037807,32.033673 25.78533,4.279525"
+       style="clip-rule:evenodd;display:inline;fill:none;fill-rule:evenodd;stroke:#221e0c;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1"
+       id="path53" />
+    <path
+       style="fill:none;stroke:#3465a4;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 53.635795,9.8385748 38.057013,54.720475"
+       id="path48" />
+    <path
+       d="M 40.037807,32.033673 31.116287,4.279525"
+       style="clip-rule:evenodd;display:inline;fill:none;fill-rule:evenodd;stroke:#221e0c;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1"
+       id="path54" />
+    <path
+       style="fill:none;stroke:#221e0c;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 5.3642055,32.627685 40.037852,32.032883"
+       id="path893" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 5.3642055,32.627685 40.037852,32.032883"
+       id="path45" />
+    <path
+       style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 5.3566961,33.377685 40.030343,32.782883"
+       id="path46" />
+    <path
+       d="M 40.037807,32.033673 5.3642055,12.279201 Z"
+       style="clip-rule:evenodd;fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-dasharray:none"
+       id="path5" />
+    <path
+       d="M 5.3642055,5.8598907 40.037807,32.033673"
+       style="clip-rule:evenodd;fill:none;fill-rule:evenodd;stroke:#ffff00;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-dasharray:none"
+       id="path7" />
+    <path
+       d="m 40.037807,32.033673 c 0.046,-0.386 -29.673601,-27.754148 -29.673601,-27.754148"
+       style="clip-rule:evenodd;fill:none;fill-rule:evenodd;stroke:#00ff00;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-dasharray:none"
+       id="path9" />
+    <path
+       d="M 40.037807,32.033673 18.825359,4.279525"
+       style="clip-rule:evenodd;fill:none;fill-rule:evenodd;stroke:#00fffe;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-dasharray:none"
+       id="path3" />
+    <path
+       d="M 40.037807,32.033673 25.78533,4.279525"
+       style="clip-rule:evenodd;fill:none;fill-rule:evenodd;stroke:#0100ff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-dasharray:none"
+       id="path11" />
+    <path
+       d="M 40.037807,32.033673 31.116287,4.279525"
+       style="clip-rule:evenodd;fill:none;fill-rule:evenodd;stroke:#fd00ff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-dasharray:none"
+       id="path13" />
+  </g>
 </svg>

--- a/icons/lens.svg
+++ b/icons/lens.svg
@@ -1,125 +1,181 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
-   id="svg2"
+   id="svg2869"
    version="1.1"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
-   sodipodi:docname="lens.svg">
+   viewBox="0 0 64 64"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs4" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="7.9195959"
-     inkscape:cx="28.452275"
-     inkscape:cy="62.339002"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="false"
-     inkscape:window-width="3840"
-     inkscape:window-height="2093"
-     inkscape:window-x="0"
-     inkscape:window-y="36"
-     inkscape:window-maximized="1"
-     inkscape:document-rotation="0"
-     units="px" />
+     id="defs2871">
+    <linearGradient
+       id="linearGradient5">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop19" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop20" />
+    </linearGradient>
+    <linearGradient
+       id="swatch18">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="swatch15">
+      <stop
+         style="stop-color:#3d0000;stop-opacity:1;"
+         offset="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5-1">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1" />
+    </linearGradient>
+  </defs>
   <metadata
-     id="metadata7">
+     id="metadata2874">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[maxwxyz]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>2024</dc:date>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:groupmode="layer"
      id="layer3"
-     inkscape:label="Ebene#1">
-    <rect
-       style="fill:#ffcc00;stroke-width:0.0873654;stroke:#ffcc00"
-       id="rect3020"
-       width="32.949318"
-       height="7.7380972"
-       x="0.42117661"
-       y="5.3917909" />
-    <rect
-       style="fill:#ffcc00;stroke-width:0.0873654;stroke:#ffcc00"
-       id="rect3022"
-       width="32.699699"
-       height="7.488481"
-       x="0.92040718"
-       y="28.356472" />
-    <rect
-       style="fill:#ffcc00;stroke-width:0.0873654;stroke:#ffcc00"
-       id="rect3024"
-       width="31.202003"
-       height="7.2388649"
-       x="0.92040718"
-       y="51.071514" />
-    <rect
-       style="fill:#ffcc00;stroke-width:0.087;stroke:#ffcc00;stroke-miterlimit:4;stroke-dasharray:none"
-       id="rect3032"
-       width="37.192791"
-       height="5.9907846"
-       x="28.729044"
-       y="-15.25231"
-       transform="rotate(36.643743)"
-       inkscape:transform-center-x="1.4374269"
-       inkscape:transform-center-y="-6.4507203" />
-    <rect
-       style="fill:#ffcc00;stroke-width:0.0873654;stroke:#ffcc00"
-       id="rect3034"
-       width="27.208149"
-       height="6.4900169"
-       x="32.871262"
-       y="29.105322" />
-    <rect
-       style="fill:#ffcc00;stroke:#ffcc00;stroke-width:0.0873654"
-       id="rect3036"
-       width="37.941635"
-       height="5.2419367"
-       x="-13.729141"
-       y="62.212624"
-       transform="rotate(-42.886786)" />
-  </g>
-  <g
-     inkscape:label="Ebene 1"
-     inkscape:groupmode="layer"
-     id="layer1">
+     style="display:inline">
+    <path
+       style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,5.232422 60,32"
+       id="path72" />
+    <path
+       style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,58.767578 H 4"
+       id="path75" />
+    <path
+       style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,5.232422 H 4"
+       id="path79" />
+    <path
+       style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 60,32 32,58.767578"
+       id="path82" />
+    <path
+       style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,32 H 60"
+       id="path64" />
+    <path
+       style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,32 H 4"
+       id="path69" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,5.232422 60,32"
+       id="path73" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,58.767578 H 4"
+       id="path76" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,5.232422 H 4"
+       id="path80" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 60,32 32,58.767578"
+       id="path83" />
+    <path
+       style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,59.517578 H 4"
+       id="path77" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,32 H 60"
+       id="path65" />
+    <path
+       style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,5.982422 H 4"
+       id="path81" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,32 H 4"
+       id="path70" />
+    <path
+       style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 60,33.039117 32.53125,59.298828"
+       id="path84" />
+    <path
+       style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,32.75 H 59.215469"
+       id="path66" />
+    <path
+       style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,32.75 H 4"
+       id="path71" />
+    <path
+       style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 31.46875,5.7636719 60,33.039117"
+       id="path78" />
     <ellipse
-       style="fill:#204a87;stroke-width:0.0873654"
-       id="path3011"
-       cx="32.247223"
-       cy="31.851099"
-       rx="7.6132898"
-       ry="28.705847" />
-  </g>
-  <g
-     inkscape:groupmode="layer"
-     id="layer2"
-     inkscape:label="Ebene">
-    <ellipse
-       style="fill:#729fcf;stroke-width:0.0873654"
-       id="path3015"
-       cx="31.997604"
-       cy="31.851099"
-       rx="5.6163607"
-       ry="25.21122" />
+       style="fill:#729fcf;fill-opacity:1;stroke:#0c1522;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       id="path56"
+       cx="32"
+       cy="32"
+       rx="6.4653049"
+       ry="28.768213" />
+    <path
+       style="fill:#3465a4;fill-opacity:1;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       id="ellipse56"
+       d="m 32,5.2324219 c 0,0 0.01859,0.040631 0.386719,0.5859375 C 34.59029,9.0824542 36.464844,19.386592 36.464844,32 c 0,12.613408 -1.874554,22.917546 -4.078125,26.181641 C 32.018585,58.726947 32,58.767578 32,58.767578 c 0,0 -0.01859,-0.04063 -0.386719,-0.585937 C 29.40971,54.917546 27.535156,44.613408 27.535156,32 27.535156,19.386592 29.40971,9.0824542 31.613281,5.8183594 31.981415,5.2730527 32,5.2324219 32,5.2324219 Z" />
   </g>
 </svg>

--- a/icons/mirror.svg
+++ b/icons/mirror.svg
@@ -1,64 +1,122 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
-   viewBox="0 0 16.933333 16.933333"
+   id="svg2869"
    version="1.1"
-   id="svg8"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
-   sodipodi:docname="mirror.svg">
+   viewBox="0 0 64 64"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="7.9195959"
-     inkscape:cx="56.946197"
-     inkscape:cy="87.999846"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
-     inkscape:document-rotation="0"
-     showgrid="false"
-     units="px"
-     inkscape:window-width="3840"
-     inkscape:window-height="2093"
-     inkscape:window-x="0"
-     inkscape:window-y="36"
-     inkscape:window-maximized="1" />
+     id="defs2871">
+    <linearGradient
+       id="linearGradient5">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop19" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop20" />
+    </linearGradient>
+    <linearGradient
+       id="swatch18">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="swatch15">
+      <stop
+         style="stop-color:#3d0000;stop-opacity:1;"
+         offset="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5-1">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1" />
+    </linearGradient>
+  </defs>
   <metadata
-     id="metadata5">
+     id="metadata2874">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[maxwxyz]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>2024</dc:date>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Ebene 1"
-     inkscape:groupmode="layer"
-     id="layer1">
+     id="layer3"
+     style="display:inline">
     <path
-       style="fill:none;stroke:#0000ff;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 15.53963,0.87835183 10.166636,16.485171"
+       style="fill:none;stroke:#0b1523;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 53.635795,9.8385748 38.057013,54.720475"
+       id="path47" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:12;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 53.635795,9.8385748 38.057013,54.720475"
        id="path833" />
     <path
-       style="fill:none;stroke:#ffcc00;stroke-width:0.96679;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 0.02473875,9.8999079 10.459893,9.1758956 v -0.01157 L 0.81157632,-0.21539165"
+       style="fill:none;stroke:#3465a4;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 53.635795,9.8385748 38.057013,54.720475"
+       id="path48" />
+    <path
+       style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 5.2834861,38.423768 39.930672,36.019876 v -0.03842 L 7.8959734,4.8385748"
        id="path835" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 5.2834861,38.423768 39.930672,36.019876 v -0.03842 L 7.8959734,4.8385748"
+       id="path54" />
+    <path
+       style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 5.1723655,39.164613 39.687604,36.769876 v -0.03842 L 7.3054768,5.2508183"
+       id="path55" />
   </g>
 </svg>

--- a/icons/ray.svg
+++ b/icons/ray.svg
@@ -1,78 +1,69 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
+   width="64"
+   height="64"
+   id="svg2869"
+   version="1.1"
+   viewBox="0 0 64 64"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
-   id="svg2980"
-   sodipodi:version="0.32"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
-   sodipodi:docname="ray.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   version="1.1">
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2982">
-    <inkscape:path-effect
-       effect="spiro"
-       id="path-effect851"
-       is_visible="true"
-       lpeversion="1" />
+     id="defs2871">
     <linearGradient
-       id="linearGradient3864">
+       id="linearGradient5">
       <stop
-         id="stop3866"
+         style="stop-color:#ef2929;stop-opacity:1;"
          offset="0"
-         style="stop-color:#71b2f8;stop-opacity:1;" />
+         id="stop19" />
       <stop
-         id="stop3868"
+         style="stop-color:#ef2929;stop-opacity:0;"
          offset="1"
-         style="stop-color:#002795;stop-opacity:1;" />
+         id="stop20" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective2988" />
+    <linearGradient
+       id="swatch18">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="swatch15">
+      <stop
+         style="stop-color:#3d0000;stop-opacity:1;"
+         offset="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5-1">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1" />
+    </linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="6.8105468"
-     inkscape:cx="27.728608"
-     inkscape:cy="77.935711"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="3840"
-     inkscape:window-height="2093"
-     inkscape:window-x="0"
-     inkscape:window-y="36"
-     inkscape:snap-bbox="true"
-     inkscape:snap-nodes="false"
-     inkscape:window-maximized="1"
-     inkscape:document-rotation="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid2991"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
-     id="metadata2985">
+     id="metadata2874">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -81,47 +72,54 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>[triplus]</dc:title>
+            <dc:title>[maxwxyz]</dc:title>
           </cc:Agent>
         </dc:creator>
-        <dc:title />
-        <dc:date>2016-02-26</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Part/Gui/Resources/icons/PartWorkbench.svg</dc:identifier>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
           </cc:Agent>
         </dc:rights>
-        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
-        <dc:contributor>
-          <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
-          </cc:Agent>
-        </dc:contributor>
+        <dc:date>2024</dc:date>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
-    <path
-       style="fill:none;stroke:#ffd42a;stroke-width:4.11271;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 9.939637,32.204357 53.990027,0.171281"
-       id="path849"
-       inkscape:path-effect="#path-effect851"
-       inkscape:original-d="m 9.939637,32.204357 53.990027,0.171281" />
+     id="layer3"
+     style="display:inline">
+    <g
+       id="g84"
+       transform="translate(5.5126565)">
+      <path
+         style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32 H 4"
+         id="path69" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32 H 4"
+         id="path70" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32.75 H 4"
+         id="path71" />
+    </g>
     <circle
-       style="fill:#ffff00;stroke:#d4aa00;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906"
+       style="fill:#fce94f;stroke:#221e0c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
        id="path853"
-       cx="9.528821"
-       cy="32.413795"
+       cx="9.5121803"
+       cy="32"
        r="6" />
+    <path
+       style="fill:#edd400;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="circle84"
+       d="m 9.5292969,28 c 2.1990401,0 4.0000001,1.800959 4.0000001,4 0,2.199041 -1.80096,4 -4.0000001,4 -2.1990406,0 -4,-1.800959 -4,-4 0,-2.199041 1.8009594,-4 4,-4 z"
+       transform="translate(-0.01664045)" />
   </g>
 </svg>

--- a/icons/rayarray.svg
+++ b/icons/rayarray.svg
@@ -1,98 +1,69 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
+   width="64"
+   height="64"
+   id="svg2869"
+   version="1.1"
+   viewBox="0 0 64 64"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
-   id="svg2980"
-   sodipodi:version="0.32"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
-   sodipodi:docname="rayarray.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   version="1.1">
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2982">
-    <inkscape:path-effect
-       effect="spiro"
-       id="path-effect907"
-       is_visible="true"
-       lpeversion="1" />
-    <inkscape:path-effect
-       effect="spiro"
-       id="path-effect892"
-       is_visible="true"
-       lpeversion="1" />
-    <inkscape:path-effect
-       effect="spiro"
-       id="path-effect877"
-       is_visible="true"
-       lpeversion="1" />
-    <inkscape:path-effect
-       effect="spiro"
-       id="path-effect862"
-       is_visible="true"
-       lpeversion="1" />
-    <inkscape:path-effect
-       effect="spiro"
-       id="path-effect851"
-       is_visible="true"
-       lpeversion="1" />
+     id="defs2871">
     <linearGradient
-       id="linearGradient3864">
+       id="linearGradient5">
       <stop
-         id="stop3866"
+         style="stop-color:#ef2929;stop-opacity:1;"
          offset="0"
-         style="stop-color:#71b2f8;stop-opacity:1;" />
+         id="stop19" />
       <stop
-         id="stop3868"
+         style="stop-color:#ef2929;stop-opacity:0;"
          offset="1"
-         style="stop-color:#002795;stop-opacity:1;" />
+         id="stop20" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective2988" />
+    <linearGradient
+       id="swatch18">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="swatch15">
+      <stop
+         style="stop-color:#3d0000;stop-opacity:1;"
+         offset="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5-1">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1" />
+    </linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="6.8105468"
-     inkscape:cx="27.728608"
-     inkscape:cy="40.744929"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="3840"
-     inkscape:window-height="2093"
-     inkscape:window-x="0"
-     inkscape:window-y="36"
-     inkscape:snap-bbox="true"
-     inkscape:snap-nodes="false"
-     inkscape:window-maximized="1"
-     inkscape:document-rotation="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid2991"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
-     id="metadata2985">
+     id="metadata2874">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -101,95 +72,162 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>[triplus]</dc:title>
+            <dc:title>[maxwxyz]</dc:title>
           </cc:Agent>
         </dc:creator>
-        <dc:title />
-        <dc:date>2016-02-26</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Part/Gui/Resources/icons/PartWorkbench.svg</dc:identifier>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
           </cc:Agent>
         </dc:rights>
-        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
-        <dc:contributor>
-          <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
-          </cc:Agent>
-        </dc:contributor>
+        <dc:date>2024</dc:date>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
-    <path
-       style="fill:none;stroke:#ffd42a;stroke-width:4.11271;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 9.939637,32.204357 53.990027,0.171281"
-       id="path849"
-       inkscape:path-effect="#path-effect851"
-       inkscape:original-d="m 9.939637,32.204357 53.990027,0.171281" />
+     id="layer3"
+     style="display:inline">
+    <g
+       id="g84"
+       transform="translate(5.5126565)">
+      <path
+         style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32 H 4"
+         id="path69" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32 H 4"
+         id="path70" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32.75 H 4"
+         id="path71" />
+    </g>
     <circle
-       style="fill:#ffff00;stroke:#d4aa00;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906"
+       style="fill:#fce94f;stroke:#221e0c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
        id="path853"
-       cx="9.528821"
-       cy="32.413795"
+       cx="9.5121803"
+       cy="32"
        r="6" />
     <path
-       style="fill:none;stroke:#ffd42a;stroke-width:4.11271;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 9.8987889,44.121621 63.888816,44.292902"
-       id="path849-3"
-       inkscape:path-effect="#path-effect862"
-       inkscape:original-d="M 9.8987889,44.121621 63.888816,44.292902" />
+       style="fill:#edd400;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="circle84"
+       d="m 9.5292969,28 c 2.1990401,0 4.0000001,1.800959 4.0000001,4 0,2.199041 -1.80096,4 -4.0000001,4 -2.1990406,0 -4,-1.800959 -4,-4 0,-2.199041 1.8009594,-4 4,-4 z"
+       transform="translate(-0.01664045)" />
+    <g
+       id="g86"
+       transform="translate(5.5126565,-12)">
+      <path
+         style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32 H 4"
+         id="path84" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32 H 4"
+         id="path85" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32.75 H 4"
+         id="path86" />
+    </g>
     <circle
-       style="fill:#ffff00;stroke:#d4aa00;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906"
-       id="path853-6"
-       cx="9.4879732"
-       cy="44.331059"
+       style="fill:#fce94f;stroke:#221e0c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="circle86"
+       cx="9.5121803"
+       cy="20"
        r="6" />
     <path
-       style="fill:none;stroke:#ffd42a;stroke-width:4.11271;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 9.994824,56.45295 53.990027,0.171281"
-       id="path849-7"
-       inkscape:path-effect="#path-effect877"
-       inkscape:original-d="m 9.994824,56.45295 53.990027,0.171281" />
+       style="fill:#edd400;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="path87"
+       d="m 9.5292969,28 c 2.1990401,0 4.0000001,1.800959 4.0000001,4 0,2.199041 -1.80096,4 -4.0000001,4 -2.1990406,0 -4,-1.800959 -4,-4 0,-2.199041 1.8009594,-4 4,-4 z"
+       transform="translate(-0.01664045,-12)" />
+    <g
+       id="g90"
+       transform="translate(5.5126565,12)">
+      <path
+         style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32 H 4"
+         id="path88" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32 H 4"
+         id="path89" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32.75 H 4"
+         id="path90" />
+    </g>
     <circle
-       style="fill:#ffff00;stroke:#d4aa00;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906"
-       id="path853-5"
-       cx="9.5840073"
-       cy="56.662388"
+       style="fill:#fce94f;stroke:#221e0c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="circle90"
+       cx="9.5121803"
+       cy="44"
        r="6" />
     <path
-       style="fill:none;stroke:#ffd42a;stroke-width:4.11271;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 9.8391477,20.239913 63.829175,20.411194"
-       id="path849-35"
-       inkscape:path-effect="#path-effect892"
-       inkscape:original-d="M 9.8391477,20.239913 63.829175,20.411194" />
+       style="fill:#edd400;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="path91"
+       d="m 9.5292969,28 c 2.1990401,0 4.0000001,1.800959 4.0000001,4 0,2.199041 -1.80096,4 -4.0000001,4 -2.1990406,0 -4,-1.800959 -4,-4 0,-2.199041 1.8009594,-4 4,-4 z"
+       transform="translate(-0.01664045,12)" />
+    <g
+       id="g94"
+       transform="translate(5.5126565,24)">
+      <path
+         style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32 H 4"
+         id="path92" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32 H 4"
+         id="path93" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32.75 H 4"
+         id="path94" />
+    </g>
     <circle
-       style="fill:#ffff00;stroke:#d4aa00;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906"
-       id="path853-62"
-       cx="9.4283314"
-       cy="20.44935"
+       style="fill:#fce94f;stroke:#221e0c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="circle94"
+       cx="9.5121803"
+       cy="56"
        r="6" />
     <path
-       style="fill:none;stroke:#ffd42a;stroke-width:4.11271;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 9.7693438,8.4212249 63.759371,8.5925059"
-       id="path849-9"
-       inkscape:path-effect="#path-effect907"
-       inkscape:original-d="M 9.7693438,8.4212249 63.759371,8.5925059" />
+       style="fill:#edd400;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="path95"
+       d="m 9.5292969,28 c 2.1990401,0 4.0000001,1.800959 4.0000001,4 0,2.199041 -1.80096,4 -4.0000001,4 -2.1990406,0 -4,-1.800959 -4,-4 0,-2.199041 1.8009594,-4 4,-4 z"
+       transform="translate(-0.01664045,24)" />
+    <g
+       id="g98"
+       transform="translate(5.5126565,-24)">
+      <path
+         style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32 H 4"
+         id="path96" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32 H 4"
+         id="path97" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 52.975163,32.75 H 4"
+         id="path98" />
+    </g>
     <circle
-       style="fill:#ffff00;stroke:#d4aa00;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:75.5906"
-       id="path853-1"
-       cx="9.3585281"
-       cy="8.6306629"
+       style="fill:#fce94f;stroke:#221e0c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="circle98"
+       cx="9.5121803"
+       cy="8"
        r="6" />
+    <path
+       style="fill:#edd400;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="path99"
+       d="m 9.5292969,28 c 2.1990401,0 4.0000001,1.800959 4.0000001,4 0,2.199041 -1.80096,4 -4.0000001,4 -2.1990406,0 -4,-1.800959 -4,-4 0,-2.199041 1.8009594,-4 4,-4 z"
+       transform="translate(-0.01664045,-24)" />
   </g>
 </svg>

--- a/icons/raysun.svg
+++ b/icons/raysun.svg
@@ -1,160 +1,211 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
-   viewBox="0 0 16.933333 16.933333"
+   id="svg2869"
    version="1.1"
-   id="svg42"
-   sodipodi:docname="raysun.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   viewBox="0 0 64 64"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2871">
+    <linearGradient
+       id="linearGradient5">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop19" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop20" />
+    </linearGradient>
+    <linearGradient
+       id="swatch18">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="swatch15">
+      <stop
+         style="stop-color:#3d0000;stop-opacity:1;"
+         offset="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5-1">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1" />
+    </linearGradient>
+  </defs>
   <metadata
-     id="metadata48">
+     id="metadata2874">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[maxwxyz]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>2024</dc:date>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs
-     id="defs46" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="3840"
-     inkscape:window-height="2093"
-     id="namedview44"
-     showgrid="false"
-     units="px"
-     inkscape:zoom="45.254834"
-     inkscape:cx="21.11697"
-     inkscape:cy="41.870954"
-     inkscape:window-x="0"
-     inkscape:window-y="36"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Ray" />
   <g
-     id="Ray"
-     transform="matrix(1,0,0,-1,0.06633183,-0.14780199)">
-    <path
-       id="Ray_nwe0000"
-       d="M -0.05902655,-11.813497 H 16.838811"
-       stroke="#8300b5"
-       stroke-width="0.35 px"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:0.726793;stroke-miterlimit:4;stroke-dasharray:none" />
-    <title
-       id="title3">b'Ray'</title>
-  </g>
-  <g
-     id="Ray001"
-     transform="matrix(1.6897837,0,0,-2.5518424,0.01448179,10.887401)">
-    <path
-       id="Ray001_nwe0000"
-       d="M 0,0 H 10"
-       stroke="#0025ff"
-       stroke-width="0.35 px"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none" />
-    <title
-       id="title7">b'Ray001'</title>
-  </g>
-  <g
-     id="Ray002"
-     transform="matrix(1.6897837,0,0,-2.5518424,0.02343857,9.9829004)">
-    <path
-       id="Ray002_nwe0000"
-       d="M 0,0 H 10"
-       stroke="#00faff"
-       stroke-width="0.35 px"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none" />
-    <title
-       id="title11">b'Ray002'</title>
-  </g>
-  <g
-     id="Ray003"
-     transform="matrix(1.6897837,0,0,-2.5518424,0.02701791,9.0877919)">
-    <path
-       id="Ray003_nwe0000"
-       d="M 0,0 H 10"
-       stroke="#6aff00"
-       stroke-width="0.35 px"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none" />
-    <title
-       id="title15">b'Ray003'</title>
-  </g>
-  <g
-     id="Ray004"
-     transform="matrix(1.6897837,0,0,-2.5518424,0.04391242,8.1739577)">
-    <path
-       id="Ray004_nwe0000"
-       d="M 0,0 H 10"
-       stroke="#f9ff00"
-       stroke-width="0.35 px"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none" />
-    <title
-       id="title19">b'Ray004'</title>
-  </g>
-  <g
-     id="Ray005"
-     transform="matrix(1.6897837,0,0,-2.5518424,0.03421998,7.3180649)">
-    <path
-       id="Ray005_nwe0000"
-       d="M 0,0 H 10"
-       stroke="#ff6e00"
-       stroke-width="0.35 px"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none" />
-    <title
-       id="title23">b'Ray005'</title>
-  </g>
-  <g
-     id="Ray006"
-     transform="matrix(1.6897837,0,0,-2.5518424,0.02939971,6.4336193)">
-    <path
-       id="Ray006_nwe0000"
-       d="M 0,0 H 10"
-       stroke="#ff0000"
-       stroke-width="0.35 px"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none" />
-    <title
-       id="title27">b'Ray006'</title>
-  </g>
-  <g
-     id="Ray007"
-     transform="matrix(1.6897837,0,0,-2.5518424,0.02737427,5.5485776)">
-    <path
-       id="Ray007_nwe0000"
-       d="M 0,0 H 10"
-       stroke="#eb0000"
-       stroke-width="0.35 px"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none" />
-    <title
-       id="title31">b'Ray007'</title>
-  </g>
-  <g
-     id="Ray008"
-     transform="matrix(1.6897837,0,0,-2.5518424,0.02050382,4.689092)">
-    <path
-       id="Ray008_nwe0000"
-       d="M 0,0 H 10"
-       stroke="#960000"
-       stroke-width="0.35 px"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none" />
-    <title
-       id="title35">b'Ray008'</title>
+     id="layer3"
+     style="display:inline">
+    <g
+       id="g135"
+       transform="matrix(0.96296296,0,0,0.96271674,1.1851853,0.2303471)"
+       style="stroke-width:1.03859">
+      <path
+         id="path127"
+         d="M 5,58.677088 H 58.883269"
+         stroke="#8300b5"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path128"
+         d="M 5.0228842,52.257816 H 58.906152"
+         stroke="#0025ff"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path129"
+         d="M 5.0514453,45.838544 H 58.934714"
+         stroke="#00faff"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path130"
+         d="M 5.062859,39.419272 H 58.946127"
+         stroke="#6aff00"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path131"
+         d="M 5.1167317,33 H 59"
+         stroke="#f9ff00"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path132"
+         d="M 5.0858247,26.580729 H 58.969092"
+         stroke="#ff6e00"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path133"
+         d="M 5.070454,20.161457 H 58.953722"
+         stroke="#ff0000"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path134"
+         d="M 5.0639953,13.742185 H 58.947264"
+         stroke="#eb0000"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path135"
+         d="M 5.042087,7.322913 H 58.925355"
+         stroke="#960000"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="Ray_nwe0000"
+         d="M 5,58.677088 H 58.883269"
+         stroke="#8300b5"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         id="Ray001_nwe0000"
+         d="M 5.0228842,52.257816 H 58.906152"
+         stroke="#0025ff"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         id="Ray002_nwe0000"
+         d="M 5.0514453,45.838544 H 58.934714"
+         stroke="#00faff"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         id="Ray003_nwe0000"
+         d="M 5.062859,39.419272 H 58.946127"
+         stroke="#6aff00"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         id="Ray004_nwe0000"
+         d="M 5.1167317,33 H 59"
+         stroke="#f9ff00"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         id="Ray005_nwe0000"
+         d="M 5.0858247,26.580729 H 58.969092"
+         stroke="#ff6e00"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         id="Ray006_nwe0000"
+         d="M 5.070454,20.161457 H 58.953722"
+         stroke="#ff0000"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         id="Ray007_nwe0000"
+         d="M 5.0639953,13.742185 H 58.947264"
+         stroke="#eb0000"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         id="Ray008_nwe0000"
+         d="M 5.042087,7.322913 H 58.925355"
+         stroke="#960000"
+         stroke-width="0.35 px"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
   </g>
 </svg>

--- a/icons/scatter3D.svg
+++ b/icons/scatter3D.svg
@@ -2,72 +2,151 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="63.999996"
+   width="64"
    height="64"
-   viewBox="0 0 16.933332 16.933333"
+   id="svg2869"
    version="1.1"
-   id="svg1"
-   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
-   sodipodi:docname="scatter3D.svg"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   viewBox="0 0 64 64"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="mm"
-     inkscape:zoom="3.9156336"
-     inkscape:cx="116.45625"
-     inkscape:cy="92.19453"
-     inkscape:window-width="2560"
-     inkscape:window-height="1362"
-     inkscape:window-x="1920"
-     inkscape:window-y="40"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="layer1"
-     showgrid="false" />
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs1" />
+     id="defs2871">
+    <linearGradient
+       id="linearGradient5">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop19" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop20" />
+    </linearGradient>
+    <linearGradient
+       id="swatch18">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="swatch15">
+      <stop
+         style="stop-color:#3d0000;stop-opacity:1;"
+         offset="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5-1">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata2874">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[maxwxyz]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>2024</dc:date>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(-0.01954163,-0.00720823)">
-    <path
-       style="fill:none;stroke:#1a1a1a;stroke-width:1.99232;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.992908"
-       d="M 1.0157016,1.0033682 V 15.962198 H 15.956714 v -0.05003"
-       id="path1" />
-    <path
-       style="fill:none;stroke:#1a1a1a;stroke-width:1.99232;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.992908"
-       d="M 1.0285818,15.937183 9.6281681,8.0327487"
-       id="path2" />
-    <ellipse
-       style="fill:#ff0000;stroke:none;stroke-width:3.06745;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.992908"
+     id="layer3"
+     style="display:inline">
+    <g
+       id="g142"
+       transform="matrix(0.92857143,0,0,0.92857143,2.2405104,2.373506)"
+       style="stroke-width:1.07692">
+      <path
+         style="fill:none;stroke:#eeeeec;stroke-width:8.61539;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+         d="M 4,4 V 60 H 60"
+         id="path137" />
+      <path
+         style="fill:none;stroke:#eeeeec;stroke-width:8.61539;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+         d="M 4.0486811,59.905455 35.610377,28.389623"
+         id="path138" />
+      <path
+         style="fill:none;stroke:#1a1a1a;stroke-width:4.30769;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+         d="M 4,4 V 60 H 60"
+         id="path1" />
+      <path
+         style="fill:none;stroke:#1a1a1a;stroke-width:4.30769;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+         d="M 4.0486811,59.905455 35.610377,28.389623"
+         id="path2" />
+    </g>
+    <circle
+       style="fill:#ef2929;stroke:#0b1523;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.992908"
        id="path3"
-       cx="9.9013987"
-       cy="12.578594"
-       rx="1.5071385"
-       ry="1.4635162" />
-    <ellipse
-       style="fill:#0000ff;stroke:none;stroke-width:2.71679;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       cx="39.652481"
+       cy="45.982502"
+       r="6" />
+    <circle
+       style="fill:#729fcf;stroke:#0b1523;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.992908"
        id="path4"
-       cx="13.070866"
-       cy="4.2651806"
-       rx="1.3661498"
-       ry="1.3266083" />
-    <ellipse
-       style="fill:#00ff00;stroke:none;stroke-width:3.34712;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       cx="52.752342"
+       cy="15.247657"
+       r="6" />
+    <circle
+       style="fill:#8ae234;stroke:#0b1523;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.992908"
        id="path5"
-       cx="8.0980806"
-       cy="5.0611463"
-       rx="1.5300878"
-       ry="1.4858012" />
+       cx="24.949354"
+       cy="19.079172"
+       r="6" />
+    <path
+       style="fill:#cc0000;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       id="circle138"
+       d="m 37.652344,43.982422 c 2.19904,0 4,1.800959 4,4 0,2.19904 -1.80096,4 -4,4 -2.199041,0 -4,-1.80096 -4,-4 0,-2.199041 1.800959,-4 4,-4 z"
+       transform="translate(2,-2)" />
+    <path
+       style="fill:#3465a4;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       id="circle139"
+       d="m 50.751953,9.2480469 c 2.199041,0 4,1.8009591 4,4.0000001 0,2.19904 -1.800959,4 -4,4 -2.19904,0 -4,-1.80096 -4,-4 0,-2.199041 1.80096,-4.0000001 4,-4.0000001 z"
+       transform="translate(2,2)" />
+    <path
+       style="fill:#73d216;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       id="circle140"
+       d="m 26.949219,13.080078 c 2.19904,0 4,1.80096 4,4 0,2.199041 -1.80096,4 -4,4 -2.199041,0 -4,-1.800959 -4,-4 0,-2.19904 1.800959,-4 4,-4 z"
+       transform="translate(-2,2)" />
   </g>
 </svg>

--- a/icons/sun.svg
+++ b/icons/sun.svg
@@ -1,108 +1,177 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
-   viewBox="0 0 16.933334 16.933334"
+   id="svg2869"
    version="1.1"
-   id="svg13"
-   sodipodi:docname="sun.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   viewBox="0 0 64 64"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2871">
+    <linearGradient
+       id="linearGradient5">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop19" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop20" />
+    </linearGradient>
+    <linearGradient
+       id="swatch18">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="swatch15">
+      <stop
+         style="stop-color:#3d0000;stop-opacity:1;"
+         offset="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5-1">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1" />
+    </linearGradient>
+  </defs>
   <metadata
-     id="metadata19">
+     id="metadata2874">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[maxwxyz]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>2024</dc:date>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs
-     id="defs17" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="3840"
-     inkscape:window-height="2093"
-     id="namedview15"
-     showgrid="false"
-     units="px"
-     inkscape:zoom="13.569623"
-     inkscape:cx="58.771257"
-     inkscape:cy="20.319991"
-     inkscape:window-x="0"
-     inkscape:window-y="36"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg13"
-     inkscape:document-rotation="0" />
-  <path
-     id="Beam_nwe0000"
-     d="M 8.4753804,8.4753804 H 16.930761"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffd42a;stroke-width:1.05833;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0001"
-     d="M 8.4753804,8.4753804 14.454237,2.4965236"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffd42a;stroke-width:1.05833;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0002"
-     d="M 8.4753804,8.4753804 V 0.02"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffd42a;stroke-width:1.05833;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0003"
-     d="M 8.4753804,8.4753804 2.4965236,2.4965236"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffd42a;stroke-width:1.05833;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0004"
-     d="M 8.4753804,8.4753804 H 0.02"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffd42a;stroke-width:1.05833;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0005"
-     d="M 8.4753804,8.4753804 2.4965236,14.454237"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffd42a;stroke-width:1.05833;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0006"
-     d="M 8.4753804,8.4753804 V 16.930761"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffd42a;stroke-width:1.05833;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0007"
-     d="M 8.4753804,8.4753804 14.454237,14.454237"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffd42a;stroke-width:1.05833;stroke-miterlimit:4;stroke-dasharray:none" />
-  <ellipse
-     style="fill:#ffff00;stroke:#d4aa00;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:75.5906"
-     id="path844"
-     cx="8.4860516"
-     cy="8.4210567"
-     rx="0.91475338"
-     ry="0.91475344" />
+  <g
+     id="layer3"
+     style="display:inline">
+    <g
+       id="g3"
+       transform="rotate(-45,30.243792,27.760135)">
+      <path
+         style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 56.487582,32 H 0.48757778"
+         id="path1" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:2.99999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 56.487582,32 H 0.48757778"
+         id="path2" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 56.487582,32.75 H 0.48757778"
+         id="path3" />
+    </g>
+    <g
+       id="g6"
+       transform="rotate(45,30.243788,36.239867)">
+      <path
+         style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 56.487582,32 H 0.48757778"
+         id="path4" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:2.99999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 56.487582,32 H 0.48757778"
+         id="path5" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 56.487582,32.75 H 0.48757778"
+         id="path6" />
+    </g>
+    <g
+       id="g84"
+       transform="translate(3.5124185)">
+      <path
+         style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 56.48758,32 H 0.4875814"
+         id="path69" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 56.48758,32 H 0.4875814"
+         id="path70" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 56.48758,32.75 H 0.4875814"
+         id="path71" />
+    </g>
+    <g
+       id="g102"
+       transform="rotate(-90,30.243791,30.243791)">
+      <path
+         style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 56.487582,32 H 0.48757778"
+         id="path100" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:2.99999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 56.487582,32 H 0.48757778"
+         id="path101" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 56.487582,32.75 H 0.48757778"
+         id="path102" />
+    </g>
+    <g
+       id="g100"
+       transform="translate(22.48782)">
+      <circle
+         style="fill:#fce94f;stroke:#221e0c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+         id="path853"
+         cx="9.5121803"
+         cy="32"
+         r="6" />
+      <path
+         style="fill:#edd400;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+         id="circle84"
+         d="m 9.5292969,28 c 2.1990401,0 4.0000001,1.800959 4.0000001,4 0,2.199041 -1.80096,4 -4.0000001,4 -2.1990406,0 -4,-1.800959 -4,-4 0,-2.199041 1.8009594,-4 4,-4 z"
+         transform="translate(-0.01664045)" />
+    </g>
+  </g>
 </svg>

--- a/icons/sun3D.svg
+++ b/icons/sun3D.svg
@@ -1,341 +1,181 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
-   viewBox="0 0 16.933334 16.933334"
+   id="svg2869"
    version="1.1"
-   id="svg53"
-   sodipodi:docname="sun3D.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   viewBox="0 0 64 64"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2871">
+    <linearGradient
+       id="linearGradient5">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop19" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop20" />
+    </linearGradient>
+    <linearGradient
+       id="swatch18">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="swatch15">
+      <stop
+         style="stop-color:#3d0000;stop-opacity:1;"
+         offset="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5-1">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1" />
+    </linearGradient>
+  </defs>
   <metadata
-     id="metadata59">
+     id="metadata2874">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[maxwxyz]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>2024</dc:date>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs
-     id="defs57" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="3840"
-     inkscape:window-height="2093"
-     id="namedview55"
-     showgrid="false"
-     units="px"
-     inkscape:zoom="9.5951728"
-     inkscape:cx="-66.732408"
-     inkscape:cy="47.430697"
-     inkscape:window-x="0"
-     inkscape:window-y="36"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg53"
-     inkscape:document-rotation="0" />
-  <path
-     id="Beam_nwe0000"
-     d="M 8.4691491,8.4691491 H 16.918298"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0001"
-     d="M 8.4691491,8.4691491 14.4436,2.4946985"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0002"
-     d="M 8.4691491,8.4691491 V 0.02"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0003"
-     d="M 8.4691491,8.4691491 2.4946985,2.4946985"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0004"
-     d="M 8.4691491,8.4691491 H 0.02"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0005"
-     d="M 8.4691491,8.4691491 2.4946985,14.4436"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0006"
-     d="M 8.4691491,8.4691491 V 16.918298"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0007"
-     d="M 8.4691491,8.4691491 14.4436,14.4436"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0008"
-     d="M 8.4691491,8.4691491 H 14.4436"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0009"
-     d="M 8.4691491,8.4691491 12.693724,2.4946985"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0010"
-     d="M 8.4691491,8.4691491 V 0.02"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0011"
-     d="M 8.4691491,8.4691491 4.2445745,2.4946985"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0012"
-     d="M 8.4691491,8.4691491 H 2.4946985"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0013"
-     d="M 8.4691491,8.4691491 4.2445745,14.4436"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0014"
-     d="M 8.4691491,8.4691491 V 16.918298"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0015"
-     d="M 8.4691491,8.4691491 12.693724,14.4436"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0016"
-     d="m 8.4691491,8.4691491 v 0"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0017"
-     d="M 8.4691491,8.4691491 V 2.4946985"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0018"
-     d="M 8.4691491,8.4691491 V 0.02"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0019"
-     d="M 8.4691491,8.4691491 V 2.4946985"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0020"
-     d="m 8.4691491,8.4691491 v 0"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0021"
-     d="M 8.4691491,8.4691491 V 14.4436"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0022"
-     d="M 8.4691491,8.4691491 V 16.918298"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0023"
-     d="M 8.4691491,8.4691491 V 14.4436"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0024"
-     d="M 8.4691491,8.4691491 H 2.4946985"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0025"
-     d="M 8.4691491,8.4691491 4.2445745,2.4946985"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0026"
-     d="M 8.4691491,8.4691491 V 0.02"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0027"
-     d="M 8.4691491,8.4691491 12.693724,2.4946985"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0028"
-     d="M 8.4691491,8.4691491 H 14.4436"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0029"
-     d="M 8.4691491,8.4691491 12.693724,14.4436"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0030"
-     d="M 8.4691491,8.4691491 V 16.918298"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0031"
-     d="M 8.4691491,8.4691491 4.2445745,14.4436"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0032"
-     d="M 8.4691491,8.4691491 H 0.02"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0033"
-     d="M 8.4691491,8.4691491 2.4946985,2.4946985"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0034"
-     d="M 8.4691491,8.4691491 V 0.02"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0035"
-     d="M 8.4691491,8.4691491 14.4436,2.4946985"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0036"
-     d="M 8.4691491,8.4691491 H 16.918298"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0037"
-     d="M 8.4691491,8.4691491 14.4436,14.4436"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0038"
-     d="M 8.4691491,8.4691491 V 16.918298"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0039"
-     d="M 8.4691491,8.4691491 2.4946985,14.4436"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0048"
-     d="m 8.4691491,8.4691491 v 0"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0049"
-     d="M 8.4691491,8.4691491 V 2.4946985"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0050"
-     d="M 8.4691491,8.4691491 V 0.02"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0051"
-     d="M 8.4691491,8.4691491 V 2.4946985"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0052"
-     d="m 8.4691491,8.4691491 v 0"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0053"
-     d="M 8.4691491,8.4691491 V 14.4436"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0054"
-     d="M 8.4691491,8.4691491 V 16.918298"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
-  <path
-     id="Beam_nwe0055"
-     d="M 8.4691491,8.4691491 V 14.4436"
-     stroke="#7f7f00"
-     stroke-width="0.35 px"
-     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffcc00;stroke-width:1.05833337;stroke-miterlimit:4;stroke-dasharray:none" />
+  <g
+     id="layer3"
+     style="display:inline">
+    <path
+       style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 59.999999,32 H 3.9999999"
+       id="path69" />
+    <path
+       style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 51.427305,17.092905 -38.85461,29.81419"
+       id="path103" />
+    <path
+       style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,4 V 60.000004"
+       id="path100" />
+    <path
+       style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 46.907095,51.427305 17.092905,12.572696"
+       id="path106" />
+    <path
+       style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 46.907094,12.572695 17.092905,51.427305"
+       id="path114" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 46.907094,12.572695 17.092905,51.427305"
+       id="path115" />
+    <path
+       style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 47.502109,13.029266 17.68792,51.883876"
+       id="path116" />
+    <path
+       style="fill:none;stroke:#231f0b;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 51.427305,46.907095 12.572696,17.092906"
+       id="path117" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 59.999999,32 H 3.9999999"
+       id="path70" />
+    <path
+       style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 59.999999,32.75 H 3.9999999"
+       id="path71" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:2.99999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,4 V 60.000004"
+       id="path101" />
+    <path
+       style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32.75,4 V 60.000004"
+       id="path102" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 51.427305,17.092905 -38.85461,29.81419"
+       id="path104" />
+    <path
+       style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 51.883876,17.68792 13.029266,47.50211"
+       id="path105" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 46.907095,51.427305 17.092905,12.572696"
+       id="path107" />
+    <path
+       style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 46.31208,51.883876 16.49789,13.029267"
+       id="path108" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 51.427305,46.907095 12.572696,17.092906"
+       id="path118" />
+    <path
+       style="fill:none;stroke:#edd400;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 50.970734,47.50211 12.116125,17.687921"
+       id="path119" />
+    <circle
+       style="fill:#fce94f;stroke:#221e0c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="path853"
+       cx="32"
+       cy="32"
+       r="6" />
+    <path
+       style="fill:#edd400;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:75.5906;stroke-opacity:1"
+       id="circle84"
+       d="m 9.5292969,28 c 2.1990401,0 4.0000001,1.800959 4.0000001,4 0,2.199041 -1.80096,4 -4.0000001,4 -2.1990406,0 -4,-1.800959 -4,-4 0,-2.199041 1.8009594,-4 4,-4 z"
+       transform="translate(22.47118)" />
+  </g>
 </svg>

--- a/optics_workbench_icon.svg
+++ b/optics_workbench_icon.svg
@@ -2,446 +2,122 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
-   viewBox="0 0 16.933333 16.933334"
+   id="svg2869"
    version="1.1"
-   id="svg8"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="pyrate_logo_3_16x16.svg"
-   inkscape:export-filename="C:\Users\Ali\Documents\inkscape\freecad\pyrate\pyrate_logo_3_256x256.png"
-   inkscape:export-xdpi="1536"
-   inkscape:export-ydpi="1536">
+   viewBox="0 0 64 64"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2">
+     id="defs2871">
     <linearGradient
-       id="linearGradient1245"
-       inkscape:collect="always">
+       id="linearGradient5">
       <stop
-         id="stop1241"
+         style="stop-color:#ef2929;stop-opacity:1;"
          offset="0"
-         style="stop-color:#aaccff;stop-opacity:1" />
+         id="stop19" />
       <stop
-         id="stop1243"
+         style="stop-color:#ef2929;stop-opacity:0;"
          offset="1"
-         style="stop-color:#d5f6ff;stop-opacity:1" />
+         id="stop20" />
     </linearGradient>
     <linearGradient
-       id="linearGradient1167"
-       inkscape:collect="always">
+       id="swatch18">
       <stop
-         id="stop1161"
+         style="stop-color:#ef2929;stop-opacity:1;"
          offset="0"
-         style="stop-color:#00112b;stop-opacity:1" />
-      <stop
-         id="stop1163"
-         offset="1"
-         style="stop-color:#2a7fff;stop-opacity:1" />
+         id="stop18" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1166">
+       id="swatch15">
       <stop
-         style="stop-color:#41dcff;stop-opacity:1"
+         style="stop-color:#3d0000;stop-opacity:1;"
          offset="0"
-         id="stop1162" />
-      <stop
-         style="stop-color:#40e0ff;stop-opacity:1"
-         offset="1"
-         id="stop1164" />
+         id="stop15" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1058">
+       id="linearGradient5-1">
       <stop
-         style="stop-color:#5175ff;stop-opacity:1"
+         style="stop-color:#ef2929;stop-opacity:1;"
          offset="0"
-         id="stop1054" />
+         id="stop5" />
       <stop
-         style="stop-color:#40e0ff;stop-opacity:1"
+         style="stop-color:#ef2929;stop-opacity:0;"
          offset="1"
-         id="stop1056" />
+         id="stop6" />
     </linearGradient>
     <linearGradient
-       id="linearGradient1045"
-       inkscape:collect="always">
-      <stop
-         id="stop1041"
-         offset="0"
-         style="stop-color:#293449;stop-opacity:1" />
-      <stop
-         id="stop1043"
-         offset="1"
-         style="stop-color:#485c80;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient2480">
-      <stop
-         style="stop-color:#cc0a08;stop-opacity:1"
-         offset="0"
-         id="stop2476" />
-      <stop
-         style="stop-color:#f67d89;stop-opacity:1"
-         offset="1"
-         id="stop2478" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient942-5"
-       inkscape:collect="always">
-      <stop
-         id="stop938"
-         offset="0"
-         style="stop-color:#002076;stop-opacity:1" />
-      <stop
-         id="stop940"
-         offset="1"
-         style="stop-color:#40e0ff;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="31.377413"
-       x2="86.543877"
-       y1="282.62048"
-       x1="20.010984"
-       id="linearGradient944"
-       xlink:href="#linearGradient942-5"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="112.66277"
-       x2="98.204803"
-       y1="257.94366"
-       x1="13.302045"
-       id="linearGradient952"
-       xlink:href="#linearGradient2480"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(0,1.5875)"
-       gradientUnits="userSpaceOnUse"
-       y2="133.50244"
-       x2="146.68025"
-       y1="272.83194"
-       x1="101.05925"
-       id="linearGradient960"
-       xlink:href="#linearGradient2480"
-       inkscape:collect="always" />
-    <filter
-       id="filter1495"
-       inkscape:label="Drop Shadow"
-       style="color-interpolation-filters:sRGB">
-      <feFlood
-         id="feFlood1485"
-         result="flood"
-         flood-color="rgb(0,0,0)"
-         flood-opacity="0.498039" />
-      <feComposite
-         id="feComposite1487"
-         result="composite1"
-         operator="in"
-         in2="SourceGraphic"
-         in="flood" />
-      <feGaussianBlur
-         id="feGaussianBlur1489"
-         result="blur"
-         stdDeviation="4"
-         in="composite1" />
-      <feOffset
-         id="feOffset1491"
-         result="offset"
-         dy="4"
-         dx="2" />
-      <feComposite
-         id="feComposite1493"
-         result="composite2"
-         operator="over"
-         in2="offset"
-         in="SourceGraphic" />
-    </filter>
-    <filter
-       id="filter2066"
-       inkscape:label="Drop Shadow"
-       style="color-interpolation-filters:sRGB">
-      <feFlood
-         id="feFlood2056"
-         result="flood"
-         flood-color="rgb(0,0,0)"
-         flood-opacity="0.498039" />
-      <feComposite
-         id="feComposite2058"
-         result="composite1"
-         operator="in"
-         in2="SourceGraphic"
-         in="flood" />
-      <feGaussianBlur
-         id="feGaussianBlur2060"
-         result="blur"
-         stdDeviation="20"
-         in="composite1" />
-      <feOffset
-         id="feOffset2062"
-         result="offset"
-         dy="20"
-         dx="6" />
-      <feComposite
-         id="feComposite2064"
-         result="composite2"
-         operator="over"
-         in2="offset"
-         in="SourceGraphic" />
-    </filter>
-    <filter
-       id="filter2474"
-       inkscape:label="Drop Shadow"
-       style="color-interpolation-filters:sRGB">
-      <feFlood
-         id="feFlood2464"
-         result="flood"
-         flood-color="rgb(0,0,0)"
-         flood-opacity="0.498039" />
-      <feComposite
-         id="feComposite2466"
-         result="composite1"
-         operator="in"
-         in2="SourceGraphic"
-         in="flood" />
-      <feGaussianBlur
-         id="feGaussianBlur2468"
-         result="blur"
-         stdDeviation="4"
-         in="composite1" />
-      <feOffset
-         id="feOffset2470"
-         result="offset"
-         dy="4.8"
-         dx="1.5" />
-      <feComposite
-         id="feComposite2472"
-         result="composite2"
-         operator="over"
-         in2="offset"
-         in="SourceGraphic" />
-    </filter>
-    <linearGradient
-       gradientTransform="translate(0,290.28571)"
-       gradientUnits="userSpaceOnUse"
-       y2="398.20157"
-       x2="-973.7356"
-       y1="746.96252"
-       x1="-1123.2253"
-       id="linearGradient1033"
-       xlink:href="#linearGradient1058"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(0,213.65424)"
-       gradientUnits="userSpaceOnUse"
-       y2="851.35718"
-       x2="-987.59387"
-       y1="1234.0872"
-       x1="-1127.1049"
-       id="linearGradient1047"
-       xlink:href="#linearGradient1045"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-19.199562,-44.652005)"
-       gradientUnits="userSpaceOnUse"
-       y2="1157.111"
-       x2="-544.48077"
-       y1="1495.4609"
-       x1="-689.72717"
-       id="linearGradient1134"
-       xlink:href="#linearGradient1045"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="851.35718"
-       x2="-987.59387"
-       y1="1234.0872"
-       x1="-1127.1049"
-       gradientTransform="translate(0,213.65424)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient1160"
-       xlink:href="#linearGradient1166"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient3682-0">
+       id="linearGradient3836-9">
       <stop
          style="stop-color:#a40000;stop-opacity:1"
          offset="0"
-         id="stop3684-0" />
+         id="stop3838-8" />
       <stop
          style="stop-color:#ef2929;stop-opacity:1"
          offset="1"
-         id="stop3686-0" />
+         id="stop3840-1" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient3864-9">
-      <stop
-         id="stop3866-1"
-         offset="0"
-         style="stop-color:#204a87;stop-opacity:1" />
-      <stop
-         id="stop3868-1"
-         offset="1"
-         style="stop-color:#729fcf;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3682-0-3">
-      <stop
-         style="stop-color:#ff390f;stop-opacity:1"
-         offset="0"
-         id="stop3684-0-7" />
-      <stop
-         style="stop-color:#ff1000;stop-opacity:1;"
-         offset="1"
-         id="stop3686-0-5" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3864-9-7">
-      <stop
-         id="stop3866-1-7"
-         offset="0"
-         style="stop-color:#316cab;stop-opacity:1" />
-      <stop
-         id="stop3868-1-4"
-         offset="1"
-         style="stop-color:#002ca8;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3682">
-      <stop
-         id="stop3684"
-         offset="0"
-         style="stop-color:#ff6d0f;stop-opacity:1;" />
-      <stop
-         id="stop3686"
-         offset="1"
-         style="stop-color:#ff1000;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3864">
-      <stop
-         style="stop-color:#71b2f8;stop-opacity:1;"
-         offset="0"
-         id="stop3866" />
-      <stop
-         style="stop-color:#002795;stop-opacity:1;"
-         offset="1"
-         id="stop3868" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.79118995,0,0,0.96421064,-462.08318,3.6442021)"
-       gradientUnits="userSpaceOnUse"
-       y2="-97.402824"
-       x2="-2013.709"
-       y1="301.0498"
-       x1="-2412.1616"
-       id="linearGradient1169"
-       xlink:href="#linearGradient1167"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="-9.260396"
-       x2="-2055.4119"
-       y1="284.23495"
-       x1="-2302.6389"
-       id="linearGradient1239"
-       xlink:href="#linearGradient1245"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="1276.7333"
-       x2="4327.0557"
-       y1="2126.7334"
-       x1="3477.0554"
-       id="linearGradient3835"
-       xlink:href="#linearGradient1045"
-       inkscape:collect="always" />
-    <mask
-       id="mask5747"
-       maskUnits="userSpaceOnUse">
-      <path
-         inkscape:connector-curvature="0"
-         id="path5749"
-         d="m -1081.0913,3822.7064 -30.9051,-17.7313 -13.6473,4.7355 -13.0203,33.2785 -20.4811,-1.0774 -9.3432,-34.4101 -13.0752,-6.2608 -32.6113,14.2658 -13.7762,-15.3072 17.7314,-30.9049 -4.8453,-13.606 -33.2766,-13.0222 1.1905,-20.5206 34.4107,-9.3432 6.2607,-13.0752 -14.3755,-32.5713 15.3071,-13.7747 30.9051,17.7313 13.7154,-4.8866 12.9107,-33.2346 20.6323,1.1528 9.2335,34.4501 13.0752,6.2606 32.681,-14.4151 13.7747,15.3067 -17.7319,30.9052 4.7754,13.7554 33.2372,12.9128 -1.0398,20.5901 -34.4501,9.2334 -6.2622,13.0752 14.3073,32.721 z m -46.2858,-50.6793 6.3443,-3.6809 5.4951,-4.9832 4.4016,-5.9473 3.1652,-6.6122 1.8707,-7.1279 0.3036,-7.3064 -1.0584,-7.3012 -2.4077,-6.9339 -3.8305,-6.4135 -4.8341,-5.4277 -5.9468,-4.3992 -6.6122,-3.1652 -7.1283,-1.8709 -7.3452,-0.4154 -7.3041,1.0583 -6.9313,2.4077 -6.414,3.8307 -5.3875,4.9432 -4.441,5.8375 -3.1652,6.6122 -1.8143,7.2377 -0.4155,7.3456 1.0579,7.302 2.4078,6.9334 3.7905,6.3042 4.8741,5.5367 5.9468,4.3995 6.6122,3.1652 7.238,1.8142 7.3058,0.3038 7.302,-1.0584 6.9333,-2.4079 z"
-         style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.9998951;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </mask>
-    <mask
-       id="mask2314"
-       maskUnits="userSpaceOnUse">
-      <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccc"
-         id="path2316"
-         d="m -1868.9759,3355.7772 h -288.3976 v 59.668 h 119.3385 v 59.6685 h 59.668 v -59.6685 h 49.7232 v 99.4479 h 59.6679 z"
-         style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.99989414;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </mask>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="7.9195959"
-     inkscape:cx="41.636325"
-     inkscape:cy="35.147253"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:window-width="1366"
-     inkscape:window-height="705"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     units="px" />
   <metadata
-     id="metadata5">
+     id="metadata2874">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[maxwxyz]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>2024</dc:date>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-280.06666)">
-    <g
-       id="g835"
-       transform="matrix(0.09263295,0.09263295,-0.09263295,0.09263295,8.9435604,273.78657)" />
-    <g
-       id="g997"
-       transform="matrix(3.9721819,0,0,3.9728411,0.33051312,-883.61517)"
-       style="stroke-width:1.0069145">
-      <path
-         inkscape:connector-curvature="0"
-         id="path941"
-         d="m 3.9444249,293.78692 -0.5587827,0.23204 -0.5588738,0.23135 0.2800429,0.21511 -0.6846598,0.89242 -0.7219016,-0.94146 -0.082338,-0.10743 -0.117623,-0.15379 -0.2007439,-0.26183 -0.1997875,0.26146 -0.11794649,0.15388 -0.80500723,1.04942 0.40119953,0.30756 0.72178349,-0.94166 0.7219016,0.94146 0.08273,0.10772 0.1176228,0.1538 0.2003529,0.26153 0.2004788,-0.26156 0.1179464,-0.15387 0.7665011,-1 0.2792605,0.21451 0.078968,-0.59998 z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#204a87;stroke-width:0.26641279;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path971"
-         d="m 1.6478984,296.16123 -0.3242159,0.38612 0.1937551,0.16232 c 0.5220467,0.43857 1.2871942,0.43854 1.8092643,0 l 0.1937822,-0.16228 -0.3242134,-0.38612 -0.1937821,0.16227 c -0.3369665,0.28306 -0.8238757,0.28306 -1.1608352,1e-5 z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ef2929;fill-opacity:1;fill-rule:nonzero;stroke:#a40000;stroke-width:0.26641279;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path973"
-         d="m 0.52619232,293.91952 -0.32421437,-0.38611 0.19191914,-0.16229 c 0.52206888,-0.43853 1.28905711,-0.43853 1.81112821,0 l 0.1918901,0.16233 -0.3242147,0.38611 -0.1938131,-0.16224 c -0.3369666,-0.28304 -0.8238701,-0.28304 -1.16083529,0 z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ef2929;fill-opacity:1;fill-rule:nonzero;stroke:#a40000;stroke-width:0.26641279;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    </g>
+     id="layer3"
+     style="display:inline">
+    <path
+       id="path973"
+       d="M 9.7500679,15.72998 5.0490988,10.125897 7.8318439,7.7703863 c 7.5697741,-6.3649172 18.6907741,-6.3649172 26.2605801,0 l 2.782324,2.3560917 -4.700973,5.604082 -2.810206,-2.354786 c -4.885872,-4.1081017 -11.945764,-4.1081017 -16.831614,0 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ef2929;fill-opacity:1;fill-rule:nonzero;stroke:#230b0b;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       id="path39"
+       d="m 59.997058,13.368902 -8.305025,3.452226 -8.306379,3.441959 4.162196,3.200346 L 37.371951,36.740605 26.642537,22.733829 25.41877,21.135517 23.670575,18.847473 20.686976,14.95204 17.717592,18.841968 15.964588,21.131351 4.0000002,36.744325 9.9629122,41.320115 20.69057,27.310364 31.419984,41.31714 l 1.229592,1.602627 1.748193,2.288193 2.977787,3.89097 2.979659,-3.891416 1.753002,-2.289234 11.392283,-14.877717 4.150568,3.191419 1.173679,-8.926332 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#0c1522;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       id="path40"
+       d="m 26.014324,48.266632 -4.700991,5.604228 2.809365,2.355947 c 7.569453,6.365498 18.663764,6.365062 26.233556,0 l 2.809758,-2.355366 -4.700954,-5.604228 -2.809758,2.355221 c -4.885869,4.108393 -11.945844,4.108393 -16.831611,1.45e-4 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ef2929;fill-opacity:1;fill-rule:nonzero;stroke:#230b0b;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       id="path41"
+       d="m 20.962891,4.9960937 c 4.215157,0 8.428564,1.4338245 11.835937,4.2988282 l 1.265625,1.0722661 -2.136719,2.546875 -1.277343,-1.070313 c -5.634969,-4.7379517 -13.77172,-4.7366882 -19.41211,0.0059 L 9.9921875,12.90625 7.8613281,10.365234 9.1191406,9.3007813 C 12.531756,6.4313408 16.747733,4.9960938 20.962891,4.9960937 Z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#cc0000;fill-opacity:1;fill-rule:nonzero;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       id="path42"
+       d="M 56.9375,16.904297 56.236328,22.269531 55.53125,27.625 52.613281,25.380859 40.3125,41.445312 l -1.710938,2.234375 -1.357421,1.773438 -1.353516,-1.771484 -1.708984,-2.234375 -1.199219,-1.5625 -12.015625,-15.6875 -10.826172,14.140625 -2.7207031,-2.089844 10.4843751,-13.683594 1.71289,-2.236328 1.347657,-1.767578 1.359375,1.773437 1.707031,2.234375 1.193359,1.558594 12.015625,15.685547 12.66211,-16.519531 -2.929688,-2.251953 4.988281,-2.066407 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#729fcf;stroke-width:1.95113;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       transform="matrix(1.0250448,0,0,1.0250448,-0.80139589,-0.78224603)" />
+    <path
+       id="path43"
+       d="m 26.259766,51.083984 1.277343,1.070313 c 5.634861,4.738131 13.771299,4.738588 19.404297,0.002 l 1.277344,-1.072266 2.128906,2.539063 -1.279297,1.072265 c -6.821632,5.735972 -16.836373,5.736474 -23.660156,-0.002 l -1.277344,-1.070312 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#cc0000;fill-opacity:1;fill-rule:nonzero;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   </g>
 </svg>


### PR DESCRIPTION
Update icons to be consistent with FreeCAD.
Current:
Some icons hard to see with dark themes.
![grafik](https://github.com/chbergmann/OpticsWorkbench/assets/6246609/18a27e05-6ba7-4385-ab3d-675b5bfb0405)
![grafik](https://github.com/chbergmann/OpticsWorkbench/assets/6246609/caffb7cd-44da-4f31-a766-d79366283496)


New:
![grafik](https://github.com/chbergmann/OpticsWorkbench/assets/6246609/e20b53d8-188f-4654-8263-cb938a44c617)
