### PR TITLE
fix display issues with Optics icons

### DIFF
--- a/icons/Anonymous_Lightbulb_Lit.svg
+++ b/icons/Anonymous_Lightbulb_Lit.svg
@@ -26,63 +26,16 @@
          offset="1"
          id="stop148" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient5">
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1;"
-         offset="0"
-         id="stop19" />
-      <stop
-         style="stop-color:#ef2929;stop-opacity:0;"
-         offset="1"
-         id="stop20" />
-    </linearGradient>
-    <linearGradient
-       id="swatch18">
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1;"
-         offset="0"
-         id="stop18" />
-    </linearGradient>
-    <linearGradient
-       id="swatch15">
-      <stop
-         style="stop-color:#3d0000;stop-opacity:1;"
-         offset="0"
-         id="stop15" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5-1">
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1;"
-         offset="0"
-         id="stop5" />
-      <stop
-         style="stop-color:#ef2929;stop-opacity:0;"
-         offset="1"
-         id="stop6" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3836-9">
-      <stop
-         style="stop-color:#a40000;stop-opacity:1"
-         offset="0"
-         id="stop3838-8" />
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1"
-         offset="1"
-         id="stop3840-1" />
-    </linearGradient>
     <radialGradient
        xlink:href="#linearGradient147"
-       id="radialGradient148"
+       id="radialGradient1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.16244297,-0.01932539,0.06390952,0.53720282,5.6971917,-45.147441)"
        cx="88.780167"
        cy="110.20604"
        fx="88.780167"
        fy="110.20604"
-       r="89.803741"
-       gradientTransform="matrix(1.0598964,-0.12593564,0.41699233,3.5007312,-50.777645,-296.24202)"
-       gradientUnits="userSpaceOnUse" />
+       r="89.803741" />
   </defs>
   <metadata
      id="metadata2874">
@@ -117,94 +70,79 @@
      id="layer3"
      style="display:inline">
     <g
-       id="layer1"
-       transform="matrix(0.15326306,0,0,0.15345446,15.906603,1.4167983)"
-       style="stroke-width:13.0413;stroke-dasharray:none">
-      <g
-         id="g2420"
-         stroke="#000000"
-         stroke-width="9.25241"
-         transform="translate(-15.836,-7.1981)"
-         style="stroke-width:13.0413;stroke-dasharray:none">
-        <g
-           id="g1712"
-           stroke-linecap="round"
-           transform="matrix(0.84534442,0,0,0.84534442,-191.09103,-60.026924)"
-           fill="none"
-           style="fill:none;stroke:#0b1e23;stroke-width:23.1408;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1">
-          <path
-             id="path1708"
-             d="m 410.9136,440.17031 -83.82719,29.5158"
-             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             id="path1709"
-             d="m 410.9136,462.99432 -83.82719,29.5158"
-             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             id="path1710"
-             d="m 410.9136,485.81832 -83.82719,29.5158"
-             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             id="path1711"
-             d="m 410.9136,417.3463 -83.82719,29.5158"
-             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-        </g>
-        <rect
-           style="fill:#eeeeec;fill-opacity:1;stroke:#0b1d22;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-           id="rect142"
-           width="61.320667"
-           height="122.27464"
-           x="90.180725"
-           y="276.24704"
-           ry="30.857229" />
-        <g
-           id="g146"
-           stroke-linecap="round"
-           transform="matrix(0.84534442,0,0,0.84534442,-191.09103,-60.026924)"
-           fill="none"
-           style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1">
-          <path
-             id="path143"
-             d="m 410.9136,440.17031 -83.82719,29.5158"
-             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             id="path144"
-             d="m 410.9136,462.99432 -83.82719,29.5158"
-             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             id="path145"
-             d="m 410.9136,485.81832 -83.82719,29.5158"
-             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             id="path146"
-             d="m 410.9136,417.3463 -83.82719,29.5158"
-             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-        </g>
-        <path
-           style="fill:#d3d7cf;fill-opacity:1;stroke:#eeeeec;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-           id="rect143"
-           width="61.320667"
-           height="122.27464"
-           x="90.180725"
-           y="276.24704"
-           ry="30.857229"
-           d="m 120.8418,289.28711 c 9.72127,0 17.61914,7.89344 17.61914,17.81641 v 60.56054 c 0,9.92296 -7.89787,17.81641 -17.61914,17.81641 -9.72128,0 -17.61914,-7.89345 -17.61914,-17.81641 v -60.56054 c 0,-9.92297 7.89786,-17.81641 17.61914,-17.81641 z" />
-        <path
-           id="path1691"
-           stroke-linejoin="round"
-           d="m 168.43013,305.157 c -0.72,-110.85 23.75,-127.05 33.11,-139.28 14.45,-18.87 26.18,-64.95 0.72,-105.090002 -32.81,-51.9929997 -105.469995,-66.7719997 -156.909995,-10.077 -31.919,35.504 -22.182,86.367002 -4.322,114.450002 4.705,6.9 30.231,28.79 30.231,139.64 0,0.72 97.170995,0.36 97.170995,0.36 z"
-           fill="url(#linearGradient2430)"
-           fill-rule="evenodd"
-           style="display:inline;fill:#fce94f;stroke:#231f0b;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           id="path147"
-           stroke-linejoin="round"
-           d="m 84.156055,292.1503 c 7.830127,0.20927 -7.423906,0.29959 71.334175,0.01 0.59811,-48.35871 6.23549,-78.57828 13.48633,-98.15625 8.09324,-21.85252 19.37938,-32.35551 22.20899,-36.05274 10.81234,-14.11964 22.55567,-54.71408 0.0605,-90.179686 l -0.008,-0.01172 -0.008,-0.01367 C 175.08419,42.159576 148.09567,27.169474 120.0957,27.511719 98.493727,27.775761 75.257452,37.159698 55.015625,59.464844 l -0.0078,0.0098 c -27.056314,30.148275 -18.384483,74.200311 -3.15039,98.390621 0.04421,0.0362 0.722275,0.60479 1.854135,1.89354 6.602985,7.45175 28.596049,39.15762 30.444498,132.39153 z"
-           fill="url(#linearGradient2430)"
-           fill-rule="evenodd"
-           style="display:inline;fill:url(#radialGradient148);stroke:#fce94f;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
+       id="g1712"
+       stroke-linecap="round"
+       transform="matrix(0.12956007,0,0,0.12972187,-15.807667,-8.8991815)"
+       fill="none"
+       style="fill:none;stroke:#0b1e23;stroke-width:23.1408;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1">
+      <path
+         id="path1708"
+         d="m 410.9136,440.17031 -83.82719,29.5158"
+         style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path1709"
+         d="m 410.9136,462.99432 -83.82719,29.5158"
+         style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path1710"
+         d="m 410.9136,485.81832 -83.82719,29.5158"
+         style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path1711"
+         d="m 410.9136,417.3463 -83.82719,29.5158"
+         style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
     </g>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;stroke:#0b1d22;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       id="rect142"
+       width="9.3981934"
+       height="18.76359"
+       x="27.300903"
+       y="42.70356"
+       ry="4.7351794" />
+    <g
+       id="g146"
+       stroke-linecap="round"
+       transform="matrix(0.12956007,0,0,0.12972187,-15.807667,-8.8991815)"
+       fill="none"
+       style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1">
+      <path
+         id="path143"
+         d="m 410.9136,440.17031 -83.82719,29.5158"
+         style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path144"
+         d="m 410.9136,462.99432 -83.82719,29.5158"
+         style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path145"
+         d="m 410.9136,485.81832 -83.82719,29.5158"
+         style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path146"
+         d="m 410.9136,417.3463 -83.82719,29.5158"
+         style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       style="fill:#d3d7cf;fill-opacity:1;stroke:#eeeeec;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       id="rect143"
+       width="61.320667"
+       height="122.27464"
+       x="90.180725"
+       y="276.24704"
+       ry="30.857229"
+       d="m 32.000113,44.704615 c 1.489912,0 2.700363,1.211284 2.700363,2.734008 v 9.293285 c 0,1.522722 -1.210451,2.734007 -2.700363,2.734007 -1.489913,0 -2.700363,-1.211285 -2.700363,-2.734007 v -9.293285 c 0,-1.522724 1.21045,-2.734008 2.700363,-2.734008 z" />
+    <path
+       id="path1691"
+       stroke-linejoin="round"
+       d="M 39.293646,47.13992 C 39.183297,30.129494 42.933644,27.643531 44.368186,25.766783 46.582837,22.871098 48.380613,15.799916 44.478535,9.6402537 39.449974,1.661696 28.313881,-0.60620745 20.430029,8.0938931 15.538026,13.54214 17.030348,21.347295 19.767627,25.656756 c 0.721102,1.058836 4.633295,4.417954 4.633295,21.428381 0,0.110487 14.892724,0.05524 14.892724,0.05524 z"
+       fill="url(#linearGradient2430)"
+       fill-rule="evenodd"
+       style="display:inline;fill:#fce94f;stroke:#231f0b;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path147"
+       style="display:inline;fill:url(#radialGradient1);fill-rule:evenodd;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       d="M 31.886719 4.5332031 C 28.575938 4.5737216 25.01443 6.0146792 21.912109 9.4375 L 21.910156 9.4394531 C 17.763426 14.065835 19.092913 20.825002 21.427734 24.537109 C 21.434534 24.542709 21.537465 24.630363 21.710938 24.828125 C 22.722929 25.971628 26.093655 30.837387 26.376953 45.144531 C 27.577021 45.176641 25.239855 45.189001 37.310547 45.144531 C 37.402217 37.723679 38.265668 33.086355 39.376953 30.082031 C 40.617346 26.728669 42.347576 25.118137 42.78125 24.550781 C 44.438381 22.384061 46.238663 16.15524 42.791016 10.712891 L 42.789062 10.710938 L 42.789062 10.708984 C 40.314422 6.78264 36.178076 4.4806842 31.886719 4.5332031 z " />
     <path
        style="fill:none;fill-opacity:1;stroke:#fce94f;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
        d="M 30.489608,43.739282 C 30.312501,28.603051 27.132074,28.28744 26.343803,23.232841 c -0.986215,-6.32386 1.513262,2.140923 2.574643,1.262536 1.06138,-0.878387 0.07659,-7.740349 1.27064,-4.080402 1.194053,3.659948 2.2014,3.367151 3.307006,0 1.105605,-3.367151 -0.558299,7.0868 0.734795,5.147297 1.293093,-1.939503 3.285368,-6.151896 2.835933,-3.262473 C 36.541025,25.680146 32,27.66027 33.496092,43.73001"

--- a/icons/Anonymous_Lightbulb_Off.svg
+++ b/icons/Anonymous_Lightbulb_Off.svg
@@ -13,55 +13,7 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2871">
-    <linearGradient
-       id="linearGradient5">
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1;"
-         offset="0"
-         id="stop19" />
-      <stop
-         style="stop-color:#ef2929;stop-opacity:0;"
-         offset="1"
-         id="stop20" />
-    </linearGradient>
-    <linearGradient
-       id="swatch18">
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1;"
-         offset="0"
-         id="stop18" />
-    </linearGradient>
-    <linearGradient
-       id="swatch15">
-      <stop
-         style="stop-color:#3d0000;stop-opacity:1;"
-         offset="0"
-         id="stop15" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5-1">
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1;"
-         offset="0"
-         id="stop5" />
-      <stop
-         style="stop-color:#ef2929;stop-opacity:0;"
-         offset="1"
-         id="stop6" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3836-9">
-      <stop
-         style="stop-color:#a40000;stop-opacity:1"
-         offset="0"
-         id="stop3838-8" />
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1"
-         offset="1"
-         id="stop3840-1" />
-    </linearGradient>
-  </defs>
+     id="defs2871" />
   <metadata
      id="metadata2874">
     <rdf:RDF>
@@ -92,100 +44,81 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer3"
-     style="display:inline">
-    <g
-       id="layer1"
-       transform="matrix(0.15326306,0,0,0.15345446,15.906603,1.4167983)"
-       style="stroke-width:13.0413;stroke-dasharray:none">
-      <g
-         id="g2420"
-         stroke="#000000"
-         stroke-width="9.25241"
-         transform="translate(-15.836,-7.1981)"
-         style="stroke-width:13.0413;stroke-dasharray:none">
-        <g
-           id="g1712"
-           stroke-linecap="round"
-           transform="matrix(0.84534442,0,0,0.84534442,-191.09103,-60.026924)"
-           fill="none"
-           style="fill:none;stroke:#0b1e23;stroke-width:23.1408;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1">
-          <path
-             id="path1708"
-             d="m 410.9136,440.17031 -83.82719,29.5158"
-             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             id="path1709"
-             d="m 410.9136,462.99432 -83.82719,29.5158"
-             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             id="path1710"
-             d="m 410.9136,485.81832 -83.82719,29.5158"
-             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             id="path1711"
-             d="m 410.9136,417.3463 -83.82719,29.5158"
-             style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-        </g>
-        <rect
-           style="fill:#eeeeec;fill-opacity:1;stroke:#0b1d22;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-           id="rect142"
-           width="61.320667"
-           height="122.27464"
-           x="90.180725"
-           y="276.24704"
-           ry="30.857229" />
-        <g
-           id="g146"
-           stroke-linecap="round"
-           transform="matrix(0.84534442,0,0,0.84534442,-191.09103,-60.026924)"
-           fill="none"
-           style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1">
-          <path
-             id="path143"
-             d="m 410.9136,440.17031 -83.82719,29.5158"
-             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             id="path144"
-             d="m 410.9136,462.99432 -83.82719,29.5158"
-             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             id="path145"
-             d="m 410.9136,485.81832 -83.82719,29.5158"
-             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             id="path146"
-             d="m 410.9136,417.3463 -83.82719,29.5158"
-             style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-        </g>
-        <path
-           style="fill:#d3d7cf;fill-opacity:1;stroke:#eeeeec;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-           id="rect143"
-           width="61.320667"
-           height="122.27464"
-           x="90.180725"
-           y="276.24704"
-           ry="30.857229"
-           d="m 120.8418,289.28711 c 9.72127,0 17.61914,7.89344 17.61914,17.81641 v 60.56054 c 0,9.92296 -7.89787,17.81641 -17.61914,17.81641 -9.72128,0 -17.61914,-7.89345 -17.61914,-17.81641 v -60.56054 c 0,-9.92297 7.89786,-17.81641 17.61914,-17.81641 z" />
-        <path
-           id="path1691"
-           stroke-linejoin="round"
-           d="m 168.43013,305.157 c -0.72,-110.85 23.75,-127.05 33.11,-139.28 14.45,-18.87 26.18,-64.95 0.72,-105.090002 -32.81,-51.9929997 -105.469995,-66.7719997 -156.909995,-10.077 -31.919,35.504 -22.182,86.367002 -4.322,114.450002 4.705,6.9 30.231,28.79 30.231,139.64 0,0.72 97.170995,0.36 97.170995,0.36 z"
-           fill="url(#linearGradient2430)"
-           fill-rule="evenodd"
-           style="display:inline;fill:#d3d7cf;fill-opacity:1;stroke:#0b1d22;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           id="path147"
-           stroke-linejoin="round"
-           d="m 84.156055,292.1503 c 7.830127,0.20927 -7.423906,0.29959 71.334175,0.01 0.59811,-48.35871 6.23549,-78.57828 13.48633,-98.15625 8.09324,-21.85252 19.37938,-32.35551 22.20899,-36.05274 10.81234,-14.11964 22.55567,-54.71408 0.0605,-90.179686 l -0.008,-0.01172 -0.008,-0.01367 C 175.08419,42.159576 148.09567,27.169474 120.0957,27.511719 98.493727,27.775761 75.257452,37.159698 55.015625,59.464844 l -0.0078,0.0098 c -27.056314,30.148275 -18.384483,74.200311 -3.15039,98.390621 0.04421,0.0362 0.722275,0.60479 1.854135,1.89354 6.602985,7.45175 28.596049,39.15762 30.444498,132.39153 z"
-           fill="url(#linearGradient2430)"
-           fill-rule="evenodd"
-           style="display:inline;fill:#babdb6;fill-opacity:0.5;stroke:#d3d7cf;stroke-width:13.0413;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-    </g>
+     id="g1712"
+     stroke-linecap="round"
+     transform="matrix(0.12956007,0,0,0.12972187,-15.807667,-8.8991815)"
+     fill="none"
+     style="fill:none;stroke:#0b1e23;stroke-width:23.1408;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1">
     <path
-       style="fill:none;fill-opacity:1;stroke:#555753;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-       d="M 30.489608,43.739282 C 30.312501,28.603051 27.132074,28.28744 26.343803,23.232841 c -0.986215,-6.32386 1.513262,2.140923 2.574643,1.262536 1.06138,-0.878387 0.07659,-7.740349 1.27064,-4.080402 1.194053,3.659948 2.2014,3.367151 3.307006,0 1.105605,-3.367151 -0.558299,7.0868 0.734795,5.147297 1.293093,-1.939503 3.285368,-6.151896 2.835933,-3.262473 C 36.541025,25.680146 32,27.66027 33.496092,43.73001"
-       id="path148" />
+       id="path1708"
+       d="m 410.9136,440.17031 -83.82719,29.5158"
+       style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1709"
+       d="m 410.9136,462.99432 -83.82719,29.5158"
+       style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1710"
+       d="m 410.9136,485.81832 -83.82719,29.5158"
+       style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1711"
+       d="m 410.9136,417.3463 -83.82719,29.5158"
+       style="fill:none;stroke:#0b1e23;stroke-width:34.7113;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
   </g>
+  <rect
+     style="fill:#eeeeec;fill-opacity:1;stroke:#0b1d22;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     id="rect142"
+     width="9.3981934"
+     height="18.76359"
+     x="27.300903"
+     y="42.70356"
+     ry="4.7351794" />
+  <g
+     id="g146"
+     stroke-linecap="round"
+     transform="matrix(0.12956007,0,0,0.12972187,-15.807667,-8.8991815)"
+     fill="none"
+     style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1">
+    <path
+       id="path143"
+       d="m 410.9136,440.17031 -83.82719,29.5158"
+       style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path144"
+       d="m 410.9136,462.99432 -83.82719,29.5158"
+       style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path145"
+       d="m 410.9136,485.81832 -83.82719,29.5158"
+       style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path146"
+       d="m 410.9136,417.3463 -83.82719,29.5158"
+       style="fill:none;stroke:#eeeeec;stroke-width:11.5704;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+  <path
+     style="fill:#d3d7cf;fill-opacity:1;stroke:#eeeeec;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     id="rect143"
+     width="61.320667"
+     height="122.27464"
+     x="90.180725"
+     y="276.24704"
+     ry="30.857229"
+     d="m 32.000113,44.704615 c 1.489912,0 2.700363,1.211284 2.700363,2.734008 v 9.293285 c 0,1.522722 -1.210451,2.734007 -2.700363,2.734007 -1.489913,0 -2.700363,-1.211285 -2.700363,-2.734007 v -9.293285 c 0,-1.522724 1.21045,-2.734008 2.700363,-2.734008 z" />
+  <path
+     id="path1691"
+     stroke-linejoin="round"
+     d="M 39.293646,47.13992 C 39.183297,30.129494 42.933644,27.643531 44.368186,25.766783 46.582837,22.871098 48.380613,15.799916 44.478535,9.6402537 39.449974,1.661696 28.313881,-0.60620745 20.430029,8.0938931 15.538026,13.54214 17.030348,21.347295 19.767627,25.656756 c 0.721102,1.058836 4.633295,4.417954 4.633295,21.428381 0,0.110487 14.892724,0.05524 14.892724,0.05524 z"
+     fill="url(#linearGradient2430)"
+     fill-rule="evenodd"
+     style="display:inline;fill:#d3d7cf;fill-opacity:1;stroke:#0b1d22;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path147"
+     style="display:inline;fill:#babdb6;fill-opacity:1;stroke:#d3d7cf;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 31.886719 4.5332031 C 28.575941 4.5737216 25.014427 6.0146826 21.912109 9.4375 L 21.910156 9.4394531 C 17.76343 14.06583 19.092916 20.825006 21.427734 24.537109 C 21.434534 24.542709 21.537465 24.630363 21.710938 24.828125 C 22.722927 25.971627 26.093655 30.837402 26.376953 45.144531 C 27.57702 45.176641 25.239867 45.189001 37.310547 45.144531 C 37.402217 37.723687 38.265669 33.086352 39.376953 30.082031 C 40.617345 26.728673 42.347576 25.118137 42.78125 24.550781 C 44.438379 22.384063 46.238659 16.155234 42.791016 10.712891 L 42.789062 10.710938 L 42.789062 10.708984 C 40.314425 6.7826443 36.178071 4.4806843 31.886719 4.5332031 z " />
+  <path
+     style="fill:none;fill-opacity:1;stroke:#555753;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     d="M 30.489608,43.739282 C 30.312501,28.603051 27.132074,28.28744 26.343803,23.232841 c -0.986215,-6.32386 1.513262,2.140923 2.574643,1.262536 1.06138,-0.878387 0.07659,-7.740349 1.27064,-4.080402 1.194053,3.659948 2.2014,3.367151 3.307006,0 1.105605,-3.367151 -0.558299,7.0868 0.734795,5.147297 1.293093,-1.939503 3.285368,-6.151896 2.835933,-3.262473 C 36.541025,25.680146 32,27.66027 33.496092,43.73001"
+     id="path148" />
 </svg>

--- a/icons/ExportCSV.svg
+++ b/icons/ExportCSV.svg
@@ -7,6 +7,7 @@
    id="svg2869"
    version="1.1"
    viewBox="0 0 64 64"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -15,52 +16,24 @@
   <defs
      id="defs2871">
     <linearGradient
-       id="linearGradient5">
+       id="linearGradient1">
       <stop
-         style="stop-color:#ef2929;stop-opacity:1;"
+         style="stop-color:#eeeeec;stop-opacity:1"
          offset="0"
-         id="stop19" />
+         id="stop1" />
       <stop
-         style="stop-color:#ef2929;stop-opacity:0;"
+         style="stop-color:#d3d7cf;stop-opacity:1"
          offset="1"
-         id="stop20" />
+         id="stop2" />
     </linearGradient>
     <linearGradient
-       id="swatch18">
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1;"
-         offset="0"
-         id="stop18" />
-    </linearGradient>
-    <linearGradient
-       id="swatch15">
-      <stop
-         style="stop-color:#3d0000;stop-opacity:1;"
-         offset="0"
-         id="stop15" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5-1">
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1;"
-         offset="0"
-         id="stop5" />
-      <stop
-         style="stop-color:#ef2929;stop-opacity:0;"
-         offset="1"
-         id="stop6" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3836-9">
-      <stop
-         style="stop-color:#a40000;stop-opacity:1"
-         offset="0"
-         id="stop3838-8" />
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1"
-         offset="1"
-         id="stop3840-1" />
-    </linearGradient>
+       xlink:href="#linearGradient1"
+       id="linearGradient2"
+       x1="10.895791"
+       y1="2.909091"
+       x2="39.688789"
+       y2="46.851173"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
      id="metadata2874">
@@ -102,7 +75,7 @@
        x="4.1638851"
        y="3.772805" />
     <path
-       style="fill:#d3d7cf;stroke:#eeeeec;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       style="fill:url(#linearGradient2);stroke:#eeeeec;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
        id="rect148"
        width="44.92503"
        height="54.01569"
@@ -111,40 +84,34 @@
        d="M 7.2851562,6.9921875 H 48.210937 V 57.007812 H 7.2851562 Z"
        transform="translate(-1.1220482,-1.21935)" />
     <path
-       style="fill:none;stroke:#888a85;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       style="fill:none;stroke:#555753;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
        d="m 13.392116,11.657853 h 8.942082"
        id="path1" />
     <path
-       style="fill:none;stroke:#888a85;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       style="fill:none;stroke:#555753;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
        d="m 30.960913,11.66157 h 8.942086"
        id="path1-1" />
     <path
-       style="fill:none;stroke:#888a85;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       style="fill:none;stroke:#555753;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
        d="m 13.31821,18.615314 h 8.942084"
        id="path1-0" />
     <path
-       style="fill:none;stroke:#888a85;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       style="fill:none;stroke:#555753;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
        d="m 30.887005,18.619032 h 8.942086"
        id="path1-1-7" />
     <path
-       style="fill:none;stroke:#888a85;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       style="fill:none;stroke:#555753;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
        d="M 13.436138,25.605981 H 22.37822"
        id="path1-9" />
     <path
-       style="fill:none;stroke:#888a85;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
+       style="fill:none;stroke:#555753;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
        d="m 31.004932,25.609701 h 8.942084"
        id="path1-1-6" />
-    <text
-       xml:space="preserve"
-       style="font-size:14.0368px;letter-spacing:1.7546px;fill:#2e3436;stroke:#2e3436;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.992908"
-       x="10.104242"
-       y="43.37941"
+    <path
+       style="font-size:14.0368px;font-family:'Century Gothic';-inkscape-font-specification:'Century Gothic';letter-spacing:1.7546px;fill:#0b1e23;stroke:#0b1e23;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round"
+       d="m 20.458601,33.47167 -0.9056,0.67385 q -0.749461,-0.946419 -1.803391,-1.430985 -1.046124,-0.492138 -2.303034,-0.492138 -1.374012,0 -2.545046,0.643565 -1.171034,0.635994 -1.819006,1.718696 -0.640166,1.075132 -0.640166,2.422831 0,2.036693 1.436469,3.399535 1.444275,1.362842 3.638012,1.362842 2.41233,0 4.036162,-1.832265 l 0.9056,0.666278 q -0.858758,1.059989 -2.146895,1.642982 -1.280331,0.575423 -2.86513,0.575423 -3.013459,0 -4.754397,-1.945837 -1.4598885,-1.642981 -1.4598885,-3.967386 0,-2.445544 1.7643575,-4.111241 1.772165,-1.673268 4.434315,-1.673268 1.608219,0 2.904164,0.620851 1.295943,0.613279 2.123474,1.726267 z m 3.114951,6.995924 0.975861,-0.567851 q 1.030511,1.839839 2.381103,1.839839 0.57771,0 1.085158,-0.257426 0.507448,-0.264998 0.772882,-0.704135 0.265434,-0.439139 0.265434,-0.931277 0,-0.560279 -0.390344,-1.097845 -0.538676,-0.741992 -1.967336,-1.786838 -1.436469,-1.052417 -1.787779,-1.52184 -0.608938,-0.787421 -0.608938,-1.703553 0,-0.72685 0.359117,-1.324987 0.359118,-0.598136 1.007089,-0.938846 0.655779,-0.348283 1.420855,-0.348283 0.811916,0 1.514537,0.39371 0.710427,0.386139 1.498923,1.430985 l -0.936827,0.688993 q -0.647972,-0.832849 -1.108579,-1.097846 -0.452799,-0.264997 -0.991475,-0.264997 -0.694814,0 -1.139806,0.408853 -0.437186,0.408853 -0.437186,1.006989 0,0.363425 0.156137,0.704135 0.156138,0.340711 0.569903,0.741992 0.226401,0.211998 1.483311,1.112989 1.491116,1.067559 2.045405,1.900408 0.554289,0.832848 0.554289,1.673267 0,1.211415 -0.95244,2.104835 -0.944635,0.893419 -2.303034,0.893419 -1.046123,0 -1.897075,-0.537566 -0.850951,-0.545136 -1.569185,-1.817124 z m 10.27387,-9.062902 h 1.249103 l 3.801956,8.608622 3.872219,-8.608622 h 1.249103 l -4.996411,11.137452 h -0.249821 z"
        id="text1"
-       transform="scale(1.0187681,0.98157766)"><tspan
-         id="tspan1"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.0368px;font-family:'Century Gothic';-inkscape-font-specification:'Century Gothic';letter-spacing:1.7546px;fill:#2e3436;stroke:#2e3436;stroke-width:0.999998;stroke-dasharray:none"
-         x="10.104242"
-         y="43.37941">CSV</tspan></text>
+       aria-label="CSV" />
     <path
        style="fill:#729fcf;fill-opacity:1;stroke:#0c1522;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.996078"
        d="M 30.504935,54.276829 V 45.631822 H 46.628544 V 39.793629 L 59.836179,50.272432 46.457016,60.227294 V 54.276829 Z"

--- a/icons/emitter.svg
+++ b/icons/emitter.svg
@@ -1,91 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
-   width="64px"
-   height="64px"
-   id="svg2980"
-   sodipodi:version="0.32"
-   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
-   sodipodi:docname="emitter.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   width="64"
+   height="64"
+   id="svg2869"
    version="1.1"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   viewBox="0 0 64 64"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2982">
-    <inkscape:path-effect
-       effect="spiro"
-       id="path-effect851"
-       is_visible="true"
-       lpeversion="1" />
-    <linearGradient
-       id="linearGradient3864">
-      <stop
-         id="stop3866"
-         offset="0"
-         style="stop-color:#71b2f8;stop-opacity:1;" />
-      <stop
-         id="stop3868"
-         offset="1"
-         style="stop-color:#002795;stop-opacity:1;" />
-    </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective2988" />
-    <inkscape:path-effect
-       effect="spiro"
-       id="path-effect851-7"
-       is_visible="true"
-       lpeversion="1" />
-  </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="9.6315676"
-     inkscape:cx="83.164032"
-     inkscape:cy="48.17492"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="3840"
-     inkscape:window-height="2082"
-     inkscape:window-x="0"
-     inkscape:window-y="40"
-     inkscape:snap-bbox="true"
-     inkscape:snap-nodes="false"
-     inkscape:window-maximized="1"
-     inkscape:document-rotation="0"
-     inkscape:showpageshadow="2"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1">
-    <inkscape:grid
-       type="xygrid"
-       id="grid2991"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true"
-       originx="0"
-       originy="0"
-       spacingy="1"
-       spacingx="1"
-       units="px" />
-  </sodipodi:namedview>
+     id="defs2871" />
   <metadata
-     id="metadata2985">
+     id="metadata2874">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -94,126 +24,163 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>[triplus]</dc:title>
+            <dc:title>[maxwxyz]</dc:title>
           </cc:Agent>
         </dc:creator>
-        <dc:date>2016-02-26</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Part/Gui/Resources/icons/PartWorkbench.svg</dc:identifier>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
           </cc:Agent>
         </dc:rights>
-        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
-        <dc:contributor>
-          <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
-          </cc:Agent>
-        </dc:contributor>
+        <dc:date>2024</dc:date>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
-    <path
-       style="fill:none;stroke:#221e0c;stroke-width:4.48799;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 10.101458,3.6020508 17.884131,21.968982"
-       id="path893" />
-    <path
-       style="fill:none;stroke:#fce94f;stroke-width:2.244;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 10.101458,3.6020508 17.884131,21.968982"
-       id="path45" />
-    <path
-       style="fill:none;stroke:#edd400;stroke-width:1.122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 9.3946944,3.6023421 17.258329,22.160343"
-       id="path46" />
-    <path
-       style="fill:none;stroke:#221e0c;stroke-width:4.48799;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 56.002662,4.5665615 48.219989,22.933492"
-       id="path893-3" />
-    <path
-       style="fill:none;stroke:#fce94f;stroke-width:2.244;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 56.002662,4.5665615 48.219989,22.933492"
-       id="path45-6" />
-    <path
-       style="fill:none;stroke:#edd400;stroke-width:1.122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 56.709425,4.5668528 48.845791,23.124853"
-       id="path46-7" />
-    <path
-       style="fill:none;stroke:#221e0c;stroke-width:4.48799;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 43.681614,39.927796 7.782673,18.366931"
-       id="path893-5" />
-    <path
-       style="fill:none;stroke:#fce94f;stroke-width:2.244;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 43.681614,39.927796 7.782673,18.366931"
-       id="path45-3" />
-    <path
-       style="fill:none;stroke:#edd400;stroke-width:1.122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 42.97485,39.928087 7.863635,18.558001"
-       id="path46-5" />
-    <path
-       style="fill:none;stroke:#221e0c;stroke-width:4.48799;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 22.313333,39.963617 14.53066,58.330548"
-       id="path893-6" />
-    <path
-       style="fill:none;stroke:#fce94f;stroke-width:2.244;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 22.313333,39.963617 14.53066,58.330548"
-       id="path45-2" />
-    <path
-       style="fill:none;stroke:#edd400;stroke-width:1.122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 23.020097,39.963908 15.156462,58.521909"
-       id="path46-9" />
-    <path
-       style="fill:none;stroke:#221e0c;stroke-width:4.48799;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 33.242207,39.747137 0.186821,19.946911"
-       id="path893-1" />
-    <path
-       style="fill:none;stroke:#fce94f;stroke-width:2.244;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 33.242207,39.747137 0.186821,19.946911"
-       id="path45-27" />
-    <path
-       style="fill:none;stroke:#edd400;stroke-width:1.122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 32.588788,39.477767 0.188765,20.154417"
-       id="path46-0" />
-    <path
-       style="fill:none;stroke:#221e0c;stroke-width:4.48799;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 28.442769,3.2154781 28.62959,23.162389"
-       id="path893-1-9" />
-    <path
-       style="fill:none;stroke:#fce94f;stroke-width:2.244;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 28.442769,3.2154781 28.62959,23.162389"
-       id="path45-27-3" />
-    <path
-       style="fill:none;stroke:#edd400;stroke-width:1.122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 27.78935,2.9461081 27.978115,23.100525"
-       id="path46-0-6" />
-    <path
-       style="fill:none;stroke:#221e0c;stroke-width:4.48799;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 39.647077,3.0675904 39.833898,23.014502"
-       id="path893-1-0" />
-    <path
-       style="fill:none;stroke:#fce94f;stroke-width:2.244;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 39.647077,3.0675904 39.833898,23.014502"
-       id="path45-27-6" />
-    <path
-       style="fill:none;stroke:#edd400;stroke-width:1.122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 38.993658,2.7982204 39.182423,22.952638"
-       id="path46-0-2" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:6;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;image-rendering:auto;stroke-linecap:round"
-       d="M 5.2859192,47.866934 14.764411,27.676945 20,34 26,28 33.764074,33.917981 39.778,28.485231 46,34 51.668455,29.953542 60,50"
-       id="path7" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#b3b3b3;stroke-width:3.556;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;stroke-linecap:round"
-       d="m 5.3243738,48.08506 9.4784922,-20.189989 5.235589,6.323055 6,-6 7.764074,5.917981 6.01393,-5.43275 6.222,5.514769 5.66845,-4.046458 8.33155,20.046458"
-       id="path7-8" />
+     id="layer3"
+     style="display:inline">
+    <g
+       id="g18"
+       transform="matrix(0.84412851,0,0,0.84638033,4.4106373,5.4684721)"
+       style="stroke-width:1.18308">
+      <path
+         style="fill:none;fill-opacity:1;stroke:#0c1522;stroke-width:9.46461;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 5.3243738,48.08506 9.4784922,-20.189989 5.235589,6.323055 6,-6 7.764074,5.917981 6.01393,-5.43275 6.222,5.514769 5.66845,-4.046458 8.33155,20.046458"
+         id="path1" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#3465a4;stroke-width:4.73231;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 5.3243738,48.08506 9.4784922,-20.189989 5.235589,6.323055 6,-6 7.764074,5.917981 6.01393,-5.43275 6.222,5.514769 5.66845,-4.046458 8.33155,20.046458"
+         id="path7-8" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#729fcf;stroke-width:2.36615;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 4.4404903,47.643118 9.9204337,-20.543542 5.765919,5.52756 5.911612,-5.381282 7.587297,5.652816 6.190707,-5.079197 6.133612,5.072828 6.022003,-3.692905 9.127045,20.841953"
+         id="path2" />
+    </g>
+    <g
+       id="g2"
+       style="display:inline;stroke-width:1.18308"
+       transform="matrix(-0.24487513,-0.81016241,0.80800695,-0.24435683,3.3261082,35.160881)">
+      <path
+         style="fill:none;stroke:#221e0c;stroke-width:7.09846;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 7.1693612,32.293792 20.2542848,0.0056"
+         id="path893" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:3.54923;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 7.1693612,32.293792 20.2542848,0.0056"
+         id="path45" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.77462;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 6.978454,33.03364 H 27.560476"
+         id="path46" />
+    </g>
+    <g
+       id="g20"
+       style="display:inline;stroke-width:1.18308"
+       transform="matrix(0.42206426,-0.73298687,0.73103674,0.42319017,22.908792,13.157396)">
+      <path
+         style="fill:none;stroke:#221e0c;stroke-width:7.09846;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 7.1693612,32.293792 20.2542848,0.0056"
+         id="path18" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:3.54923;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 7.1693612,32.293792 20.2542848,0.0056"
+         id="path19" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.77462;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 6.978454,33.03364 H 27.560476"
+         id="path20" />
+    </g>
+    <g
+       id="g23"
+       style="display:inline;stroke-width:1.18308"
+       transform="matrix(0.42206426,-0.73298687,0.73103674,0.42319017,-12.874478,49.486419)">
+      <path
+         style="fill:none;stroke:#221e0c;stroke-width:7.09846;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 7.1693612,32.293792 20.2542848,0.0056"
+         id="path21" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:3.54923;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 7.1693612,32.293792 20.2542848,0.0056"
+         id="path22" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.77462;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 6.978454,33.03364 H 27.560476"
+         id="path23" />
+    </g>
+    <g
+       id="g26"
+       style="display:inline;stroke-width:1.18308"
+       transform="matrix(-0.42206426,-0.73298687,0.73103674,-0.42319017,-6.1328764,40.492596)">
+      <path
+         style="fill:none;stroke:#221e0c;stroke-width:7.09846;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 7.1693612,32.293792 20.2542848,0.0056"
+         id="path24" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:3.54923;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 7.1693612,32.293792 20.2542848,0.0056"
+         id="path25" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.77462;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 6.978454,33.03364 H 27.560476"
+         id="path26" />
+    </g>
+    <g
+       id="g29"
+       style="display:inline;stroke-width:1.18308"
+       transform="matrix(-0.42206426,-0.73298687,0.73103674,-0.42319017,29.650393,76.82162)">
+      <path
+         style="fill:none;stroke:#221e0c;stroke-width:7.09846;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 7.1693612,32.293792 20.2542848,0.0056"
+         id="path27" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:3.54923;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 7.1693612,32.293792 20.2542848,0.0056"
+         id="path28" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.77462;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 6.978454,33.03364 H 27.560476"
+         id="path29" />
+    </g>
+    <g
+       id="g32"
+       style="display:inline;stroke-width:1.18308"
+       transform="matrix(0.22844206,-0.81495119,0.81278299,0.22795853,8.368978,19.980839)">
+      <path
+         style="fill:none;stroke:#221e0c;stroke-width:7.09846;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 7.1693612,32.293792 20.2542848,0.0056"
+         id="path30" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:3.54923;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 7.1693612,32.293792 20.2542848,0.0056"
+         id="path31" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.77462;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 6.978454,33.03364 H 27.560476"
+         id="path32" />
+    </g>
+    <g
+       id="g47"
+       style="display:inline;stroke-width:1.18308"
+       transform="matrix(-9.7506381e-4,-0.84581738,0.84469147,9.7506785e-4,4.7362092,64.189178)">
+      <path
+         style="fill:none;stroke:#221e0c;stroke-width:7.09846;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 6.1632797,32.28374 25.647142,32.30381"
+         id="path43" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:3.54923;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 6.1632797,32.28374 25.647142,32.30381"
+         id="path44" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:1.77462;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 5.9723725,33.023588 19.8115995,0.01447"
+         id="path47" />
+    </g>
   </g>
 </svg>

--- a/icons/raysun.svg
+++ b/icons/raysun.svg
@@ -94,118 +94,45 @@
   <g
      id="layer3"
      style="display:inline">
-    <g
-       id="g135"
-       transform="matrix(0.96296296,0,0,0.96271674,1.1851853,0.2303471)"
-       style="stroke-width:1.03859">
-      <path
-         id="path127"
-         d="M 5,58.677088 H 58.883269"
-         stroke="#8300b5"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path128"
-         d="M 5.0228842,52.257816 H 58.906152"
-         stroke="#0025ff"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path129"
-         d="M 5.0514453,45.838544 H 58.934714"
-         stroke="#00faff"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path130"
-         d="M 5.062859,39.419272 H 58.946127"
-         stroke="#6aff00"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path131"
-         d="M 5.1167317,33 H 59"
-         stroke="#f9ff00"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path132"
-         d="M 5.0858247,26.580729 H 58.969092"
-         stroke="#ff6e00"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path133"
-         d="M 5.070454,20.161457 H 58.953722"
-         stroke="#ff0000"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path134"
-         d="M 5.0639953,13.742185 H 58.947264"
-         stroke="#eb0000"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path135"
-         d="M 5.042087,7.322913 H 58.925355"
-         stroke="#960000"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8.30875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="Ray_nwe0000"
-         d="M 5,58.677088 H 58.883269"
-         stroke="#8300b5"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         id="Ray001_nwe0000"
-         d="M 5.0228842,52.257816 H 58.906152"
-         stroke="#0025ff"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         id="Ray002_nwe0000"
-         d="M 5.0514453,45.838544 H 58.934714"
-         stroke="#00faff"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         id="Ray003_nwe0000"
-         d="M 5.062859,39.419272 H 58.946127"
-         stroke="#6aff00"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         id="Ray004_nwe0000"
-         d="M 5.1167317,33 H 59"
-         stroke="#f9ff00"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         id="Ray005_nwe0000"
-         d="M 5.0858247,26.580729 H 58.969092"
-         stroke="#ff6e00"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         id="Ray006_nwe0000"
-         d="M 5.070454,20.161457 H 58.953722"
-         stroke="#ff0000"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         id="Ray007_nwe0000"
-         d="M 5.0639953,13.742185 H 58.947264"
-         stroke="#eb0000"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         id="Ray008_nwe0000"
-         d="M 5.042087,7.322913 H 58.925355"
-         stroke="#960000"
-         stroke-width="0.35 px"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4.15438;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
-    </g>
+    <path
+       id="path135"
+       style="display:inline;fill:#231f0b;fill-opacity:1;fill-rule:evenodd;stroke:#231f0b;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 6.0405283,7.2802376 H 57.92812 M 6.0616252,13.460178 H 57.949217 M 6.0678447,19.640119 H 57.955436 M 6.0826461,25.820059 H 57.970237 M 6.1124084,31.999999 H 58 M 6.060531,38.17994 H 57.948122 M 6.04954,44.35988 H 57.937132 M 6.0220367,50.539821 H 57.909628 M 6.0000001,56.719762 H 57.887592" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke:#8300b5;stroke-opacity:1"
+       d="M 6.0000001,56.719761 H 57.887592"
+       id="path26" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke:#0025ff;stroke-opacity:1"
+       d="M 6.0220367,50.539821 H 57.909628"
+       id="path25" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke:#00faff;stroke-opacity:1"
+       d="M 6.04954,44.35988 H 57.937132"
+       id="path24" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke:#6aff00;stroke-opacity:1"
+       d="M 6.060531,38.17994 H 57.948122"
+       id="path23" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke:#f9ff00;stroke-opacity:1"
+       d="M 6.1124084,31.999999 H 58"
+       id="path22" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke:#ff6e00;stroke-opacity:0.99215686"
+       d="M 6.0826461,25.820059 H 57.970237"
+       id="path21" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke:#ff0000;stroke-opacity:1"
+       d="M 6.0678447,19.640119 H 57.955436"
+       id="path20" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke:#eb0000;stroke-opacity:1"
+       d="M 6.0616252,13.460178 H 57.949217"
+       id="path19" />
+    <path
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke:#960000;stroke-opacity:1"
+       d="M 6.0405283,7.2802376 H 57.92812"
+       id="path9" />
   </g>
 </svg>


### PR DESCRIPTION
@chbergmann here is a fix for the rendering of the optics icons in freecad.

Demo with light theme:
![image](https://github.com/chbergmann/OpticsWorkbench/assets/6246609/eb0f8033-d82e-4744-9ae0-204862697bac)

Demo with dark theme:
![image](https://github.com/chbergmann/OpticsWorkbench/assets/6246609/48d377e0-e7ab-4584-a10b-96c923d26423)
